### PR TITLE
restore test fix and negative tests

### DIFF
--- a/testfm/base.py
+++ b/testfm/base.py
@@ -27,7 +27,7 @@ class Base(object):
     @since: 23.Jun.2018
     """
     command_base = None  # each inherited instance should define this
-    command_sub = None  # specific to instance, like: health, upgrade, etc
+    command_sub = ''  # specific to instance, like: health, upgrade, etc
 
     @classmethod
     def _construct_command(cls, options=None):

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -2,6 +2,11 @@ from testfm.backup import Backup
 from testfm.decorators import capsule
 from testfm.log import logger
 from testfm.restore import Restore
+from fauxfactory import gen_string
+
+NODIR_MSG = "ERROR: parameter 'BACKUP_DIR': no value provided"
+BADDIR_MSG = ("The given directory does not contain the "
+              "required files or has too many files")
 
 
 @capsule
@@ -21,15 +26,79 @@ def test_positive_restore_online_backup(ansible_module):
 
     :CaseImportance: Critical
     """
+    # preparing a target dir
+    backup_dir = 'online_backup_restore'
+    setup = ansible_module.command("rm -rf /tmp/{}".format(backup_dir))
+    assert setup.values()[0]["rc"] == 0
+    setup = ansible_module.file(
+            path="/tmp/{}".format(backup_dir),
+            state="directory",
+            owner="postgres",
+    )
+    # saving backup to specified dir
     setup = ansible_module.command(Backup.run_online_backup([
-        '-y', '/tmp/online_backup_restore/']))
+        '-y', '--preserve-directory', '/tmp/{}'.format(backup_dir)]))
     for result in setup.values():
         logger.info(result['stdout'])
         assert "FAIL" not in result['stdout']
         assert result['rc'] == 0
+    # restore from previously saved backup
     contacted = ansible_module.command(Restore._construct_command(
-        ['-y', '/tmp/online_backup_restore/']))
+        ['-y', '/tmp/{}'.format(backup_dir)]))
     for result in contacted.values():
         logger.info(result)
         assert "FAIL" not in result['stdout']
         assert result['rc'] == 0
+
+
+@capsule
+def test_negative_restore_nodir(ansible_module):
+    """Restore without specified source dir
+
+    :id: c0eeb8fb-e6ca-40c7-8c25-b5a4e3cb7827
+
+    :setup:
+        1. foreman-maintain should be installed.
+
+    :steps:
+        1. Run foreman-maintain restore without providing
+        directory
+
+    :expectedresults: restore aborted, relevant message is
+        returned
+
+    :CaseImportance: Critical
+    """
+    contacted = ansible_module.command(Restore._construct_command(
+        ['-y']))
+    for result in contacted.values():
+        logger.info(result)
+        assert result['rc'] == 1
+        assert NODIR_MSG in result['stderr']
+
+
+@capsule
+def test_negative_restore_baddir(ansible_module):
+    """Restore with invalid source dir
+
+    :id: 1ea94c42-6c33-4fd5-9fe5-c53036023418
+
+    :setup:
+        1. foreman-maintain should be installed.
+
+    :steps:
+        1. Run foreman-maintain restore providing
+        invalid directory
+
+    :expectedresults: restore aborted, relevant message is
+        returned
+
+    :CaseImportance: Critical
+    """
+    contacted = ansible_module.command(Restore._construct_command([
+        '-y', gen_string('alpha')
+    ]))
+    for result in contacted.values():
+        logger.info(result['stderr'])
+        assert result['rc'] == 1
+        assert BADDIR_MSG in result['stdout']


### PR DESCRIPTION
fixes #10 
Test results, tried with p3:
```
pytest --ansible-host-pattern satellite --ansible-user=root  --ansible-inventory testfm/inventory tests/test_restore.py::test_positive_restore_online_backup
========================================= test session starts ==========================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.6.0, pluggy-0.6.0
ansible: 2.6.3
rootdir: /home/pondrejk/Documents/testfm, inifile:
plugins: ansible-2.0.1
collected 1 item                                                                                       

tests/test_restore.py .                                                                          [100%]

====================================== 1 passed in 950.56 seconds ======================================
pytest --ansible-host-pattern satellite --ansible-user=root  --ansible-inventory testfm/inventory tests/test_restore.py::test_negative_restore_nodir
========================================= test session starts ==========================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.6.0, pluggy-0.6.0
ansible: 2.6.3
rootdir: /home/pondrejk/Documents/testfm, inifile:
plugins: ansible-2.0.1
collected 1 item                                                                                       

tests/test_restore.py .                                                                          [100%]

======================================= 1 passed in 2.86 seconds =======================================
pytest --ansible-host-pattern satellite --ansible-user=root  --ansible-inventory testfm/inventory tests/test_restore.py::test_negative_restore_baddir
========================================= test session starts ==========================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.6.0, pluggy-0.6.0
ansible: 2.6.3
rootdir: /home/pondrejk/Documents/testfm, inifile:
plugins: ansible-2.0.1
collected 1 item                                                                                       

tests/test_restore.py .                                                                          [100%]

======================================= 1 passed in 5.04 seconds =======================================

```
The restore takes quite some time unfortunately, so does the test now