### PR TITLE
automated "check-upstream-repository" check

### DIFF
--- a/testfm/constants.py
+++ b/testfm/constants.py
@@ -1,0 +1,11 @@
+upstream_url = {
+    'candlepin_repo': (
+        'https://fedorapeople.org/groups/katello/releases/yum/3.8/candlepin/el7/x86_64/'),
+    'client_repo': 'https://fedorapeople.org/groups/katello/releases/yum/3.8/client/el7/x86_64/',
+    'katello_repo': (
+        'https://fedorapeople.org/groups/katello/releases/yum/latest/katello/el7/x86_64/'),
+    'plugins_repo': 'https://yum.theforeman.org/plugins/latest/el7/x86_64/',
+    'pulp_repo': 'https://fedorapeople.org/groups/katello/releases/yum/3.5/pulp/el7/x86_64/',
+    'puppet_repo': 'http://yum.puppetlabs.com/el/6.4/x86_64/',
+    'releases_repo': 'https://yum.theforeman.org/releases/latest/el7/x86_64/'
+}


### PR DESCRIPTION
Test result:

```
$ pytest --ansible-host-pattern satellite --ansible-user=root --ansible-inventory testfm/inventory tests/test_health.py -k test_positive_check_upstream_repository -svvv
========================================================================= test session starts ==========================================================================

collected 9 items / 8 deselected                                                                                                                                       

tests/test_health.py::test_positive_check_upstream_repository 2018-11-06 16:15:12,606 - testfm.log - INFO - Running ForemanMaintain::Scenario::FilteredScenario
================================================================================
Check if any upstream repositories are enabled on system: 
/ Checking for presence of upstream repositories                      [FAIL]    
System has upstream candlepin_repo,client_repo,katello_repo,plugins_repo,pulp_repo,puppet_repo,releases_repo repositories enabled
--------------------------------------------------------------------------------
Disable repositories:                                                           
/ Disabling repositories                                              [OK]      
--------------------------------------------------------------------------------
Rerunning the check after fix procedure
Check if any upstream repositories are enabled on system: 
\ Checking for presence of upstream repositories                      [OK]      
--------------------------------------------------------------------------------
PASSED

=============================================================== 1 passed, 8 deselected in 104.20 seconds ===============================================================
```