### PR TITLE
Marking tests related to puppet_check_no_empty_cert_requests check as…

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -332,6 +332,7 @@ def test_positive_automate_bz1632768(ansible_module):
     assert teardown.values()[0]["rc"] == 0
 
 
+@stubbed
 def test_positive_puppet_check_no_empty_cert_requests(ansible_module):
     """Verify puppet-check-no-empty-cert-requests
 
@@ -355,6 +356,7 @@ def test_positive_puppet_check_no_empty_cert_requests(ansible_module):
         assert result['rc'] == 0
 
 
+@stubbed
 def test_positive_puppet_check_empty_cert_requests(setup_puppet_empty_cert, ansible_module):
     """Verify puppet-check-no-empty-cert-requests
 


### PR DESCRIPTION
… stubbed, till check is available for downstream FM.