### PR TITLE
fixes test_positive_foreman_maintain_upgrade_list

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,7 +167,8 @@ def setup_sync_plan(request, ansible_module):
             org_ids.append(id['Id'])
         for id in org_ids:
             ansible_module.shell(
-                "hammer --output yaml sync-plan list --organization-id {} | sed -n '1!p' >> /tmp/sync_id.yaml".format(id))
+                "hammer --output yaml sync-plan list --organization-id {} | "
+                "sed -n '1!p' >> /tmp/sync_id.yaml".format(id))
         ansible_module.fetch(
             src="/tmp/sync_id.yaml",
             dest="./"

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -17,11 +17,13 @@ def test_positive_foreman_maintain_upgrade_list(ansible_module):
 
     :CaseImportance: Critical
     """
-    satellite_version = str(ansible_module.command(
+    satellite_version = ansible_module.command(
         "rpm -q 'satellite' --queryformat='%{VERSION}'"
-    ).values()[0]['stdout'])
-    if satellite_version.startswith('6.5'):
-        versions = ['6.5.z']
+    ).values()[0]['stdout']
+    if satellite_version.startswith('6.6'):
+        versions = []
+    elif satellite_version.startswith('6.5'):
+        versions = ['6.5.z', '6.6']
     elif satellite_version.startswith('6.4'):
         versions = ['6.4.z', '6.5']
     elif satellite_version.startswith('6.3'):
@@ -35,4 +37,4 @@ def test_positive_foreman_maintain_upgrade_list(ansible_module):
         logger.info(result['stdout'])
         assert "FAIL" not in result['stdout']
         for ver in versions:
-            assert ver in result['stdout']
+            assert ver in result['stdout_lines']


### PR DESCRIPTION
Fixes issue #75
Test Result:
```
$ pytest --ansible-host-pattern satellite --ansible-user=root  --ansible-inventory testfm/inventory tests/test_upgrade.py -k test_positive_foreman_maintain_upgrade_list 
=================================================================================== test session starts ===================================================================================
collected 1 item                                                                                                                                                                          

tests/test_upgrade.py .                                                                                                                                                             [100%]

================================================================================ 1 passed in 20.66 seconds ================================================================================
```