### PR TITLE
Fixes #111 - Add coverage for 1632111

### DIFF
--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,3 +1,4 @@
+from testfm.helpers import product
 from testfm.log import logger
 from testfm.upgrade import Upgrade
 
@@ -38,3 +39,35 @@ def test_positive_foreman_maintain_upgrade_list(ansible_module):
         assert "FAIL" not in result['stdout']
         for ver in versions:
             assert ver in result['stdout_lines']
+
+
+def test_positive_repositories_validate(ansible_module):
+    """ Test repositories-validate pre-upgrade check is
+     skipped when system is subscribed using custom activationkey.
+
+    :id: 811698c0-09da-4727-8886-077aebb2b5ed
+
+    :setup:
+        1. foreman-maintain should be installed.
+
+    :steps:
+        1. Run foreman-maintain upgrade check.
+
+    :BZ: 1632111
+
+    :expectedresults: repositories-validate check should be skipped.
+
+    :CaseImportance: Critical
+    """
+    skip_message = "Your system is subscribed using custom activation key"
+    export_command = 'export EXTERNAL_SAT_ORG=Sat6-CI;export EXTERNAL_SAT_ACTIVATION_KEY=Ext_AK;'
+    fm_command = Upgrade.check([
+        '--target-version', '{}.z'.format(product()[1]), '--whitelist',
+        '"disk-performance,check-epel-repository,check-hotfix-installed,'
+        'check-upstream-repository"', '--assumeyes'])
+    contacted = ansible_module.shell(export_command + fm_command)
+    for result in contacted.values():
+        logger.info(result['stdout'])
+        assert "SKIPPED" in result['stdout']
+        assert "FAIL" not in result['stdout']
+        assert skip_message in result['stdout']


### PR DESCRIPTION
Fixes #111 

```
$ pytest --ansible-host-pattern satellite --ansible-user=root --ansible-inventory testfm/inventory tests/test_upgrade.py -k test_positive_repositories_validate
=================================================================================== test session starts ===================================================================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.8.0, pluggy-0.6.0
ansible: 2.6.14
rootdir: /home/jpathan/projects/testfm, inifile:
plugins: ansible-2.0.1
collected 2 items / 1 deselected                                                                                                                                                          

tests/test_upgrade.py .                                                                                                                                                             [100%]

========================================================================= 1 passed, 1 deselected in 30.66 seconds =========================================================================
```