### PR TITLE
Fix epel check related tests

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -418,7 +418,7 @@ def test_positive_check_yum_exclude_list_without_excludes(ansible_module):
 
 @capsule
 def test_positive_check_epel_repository(setup_epel_repository, ansible_module):
-    """Verify check-epel-repository.
+    """Verify check-non-redhat-repository.
 
     :id: ce2d7278-d7b7-4f76-9923-79be831c0368
 
@@ -427,19 +427,19 @@ def test_positive_check_epel_repository(setup_epel_repository, ansible_module):
 
     :steps:
         1. Configure epel repository.
-        2. Run foreman-maintain health check --label check-epel-repository.
+        2. Run foreman-maintain health check --label check-non-redhat-repository.
         3. Assert that EPEL repos are enabled on system.
 
     :BZ: 1755755
 
-    :expectedresults: check-epel-repository should work.
+    :expectedresults: check-non-redhat-repository should work.
 
     :CaseImportance: Critical
     """
-    contacted = ansible_module.command(Health.check({"label": "check-epel-repository"}))
+    contacted = ansible_module.command(Health.check({"label": "check-non-redhat-repository"}))
     for result in contacted.values():
         logger.info(result["stdout"])
-        assert "System is subscribed to EPEL repository" in result["stdout"]
+        assert "System is subscribed to non Red Hat repositories" in result["stdout"]
         assert "FAIL" in result["stdout"]
         assert result["rc"] == 1
 
@@ -449,7 +449,7 @@ def test_positive_check_epel_repository(setup_epel_repository, ansible_module):
 def test_positive_check_epel_repository_with_invalid_repo(
     setup_epel_repository, setup_invalid_repository, ansible_module
 ):
-    """Verify check-epel-repository.
+    """Verify check-non-redhat-repository.
 
     :id: e41648f4-ada6-4e7e-9112-45146d308410
 
@@ -458,19 +458,19 @@ def test_positive_check_epel_repository_with_invalid_repo(
 
     :steps:
         1. Configure epel repository and a repository with invalid baseurl.
-        2. Run foreman-maintain health check --label check-epel-repository.
+        2. Run foreman-maintain health check --label check-non-redhat-repository.
         3. Assert that EPEL repos are enabled on system.
 
     :BZ: 1755755
 
-    :expectedresults: check-epel-repository should work.
+    :expectedresults: check-non-redhat-repository should work.
 
     :CaseImportance: Critical
     """
-    contacted = ansible_module.command(Health.check({"label": "check-epel-repository"}))
+    contacted = ansible_module.command(Health.check({"label": "check-non-redhat-repository"}))
     for result in contacted.values():
         logger.info(result["stdout"])
-        assert "System is subscribed to EPEL repository" in result["stdout"]
+        assert "System is subscribed to non Red Hat repositories" in result["stdout"]
         assert "FAIL" in result["stdout"]
         assert result["rc"] == 1
 
@@ -486,7 +486,7 @@ def test_positive_check_old_foreman_tasks(setup_old_foreman_tasks, ansible_modul
 
     :steps:
         1. Configure epel repository.
-        2. Run foreman-maintain health check --label check-epel-repository.
+        2. Run foreman-maintain health check --label check-non-redhat-repository.
         3. Assert that old tasks are found on system.
         4. Assert that old tasks are deleted from system.
 

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -85,7 +85,7 @@ def test_positive_repositories_validate(setup_install_pkgs, ansible_module):
             "--target-version",
             "{}.z".format(product()),
             "--whitelist",
-            '"disk-performance,check-epel-repository,check-hotfix-installed,'
+            '"disk-performance,check-non-redhat-repository,check-hotfix-installed,'
             'check-upstream-repository"',
             "--assumeyes",
         ]


### PR DESCRIPTION
Test result:

```
$ pytest -sv --ansible-host-pattern server --ansible-user root --ansible-inventory testfm/inventory tests/test_health.py -k test_positive_check_epel_repository 
============================= test session starts ==============================
collecting ... collected 21 items / 19 deselected

tests/test_health.py::test_positive_check_epel_repository 2020-06-23 18:21:40,856 - testfm.log - INFO - Running ForemanMaintain::Scenario::FilteredScenario
================================================================================
Check whether system don't have any non Red Hat repositories(Eg: EPEL) enabled: 
/ Checking repositories enabled on the system                         [FAIL]    
System is subscribed to non Red Hat repositories(Eg: EPEL)
--------------------------------------------------------------------------------
Scenario [ForemanMaintain::Scenario::FilteredScenario] failed.

The following steps ended up in failing state:

  [check-non-redhat-repository]

Resolve the failed steps and rerun
the command. In case the failures are false positives,
use --whitelist="check-non-redhat-repository"
PASSED
tests/test_health.py::test_positive_check_epel_repository_with_invalid_repo SKIPPED

============= 1 passed, 1 skipped, 19 deselected in 140.08 seconds =============

```