### PR TITLE
Issue #177 - capsule tests commit1

### DIFF
--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -254,6 +254,7 @@ def test_positive_sync_plan_disable_enable(setup_sync_plan, ansible_module):
     assert sorted(sync_ids) == sorted(data_yml[":default"][":sync_plans"][":enabled"])
 
 
+@capsule
 def test_positive_procedure_by_tag_check_migrations(ansible_module):
     """Run pre-migrations and post-migrations using advanced
     procedure by-tag

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -4,6 +4,7 @@ from testfm.health import Health
 from testfm.log import logger
 
 
+@capsule
 def test_positive_foreman_maintain_health_list(ansible_module):
     """List health check in foreman-maintain
 
@@ -25,6 +26,7 @@ def test_positive_foreman_maintain_health_list(ansible_module):
         assert result["rc"] == 0
 
 
+@capsule
 def test_positive_foreman_maintain_health_list_tags(ansible_module):
     """List tags for health check in foreman-maintain
 
@@ -46,6 +48,7 @@ def test_positive_foreman_maintain_health_list_tags(ansible_module):
         assert result["rc"] == 0
 
 
+@capsule
 def test_positive_list_health_check_by_tags(ansible_module):
     """List health check in foreman-maintain by tags
 
@@ -68,6 +71,7 @@ def test_positive_list_health_check_by_tags(ansible_module):
             assert result["rc"] == 0
 
 
+@capsule
 def test_positive_foreman_maintain_health_check(ansible_module):
     """Verify foreman-maintain health check
 
@@ -91,6 +95,7 @@ def test_positive_foreman_maintain_health_check(ansible_module):
         assert "FAIL" not in result["stdout"]
 
 
+@capsule
 def test_positive_foreman_maintain_health_check_by_tags(setup_install_pkgs, ansible_module):
     """Verify foreman-maintain health check by tags
 
@@ -111,9 +116,7 @@ def test_positive_foreman_maintain_health_check_by_tags(setup_install_pkgs, ansi
         output = result["stdout"]
     output = [i.split("]\x1b[0m")[0] for i in output.split("\x1b[36m[") if i]
     for tag in output:
-        contacted = ansible_module.command(
-            Health.check(["--tags", tag, "--whitelist", '"disk-performance"', "--assumeyes"])
-        )
+        contacted = ansible_module.command(Health.check(["--tags", tag, "--assumeyes"]))
         for result in contacted.values():
             logger.info(result["stdout"])
             assert "FAIL" not in result["stdout"]
@@ -164,6 +167,7 @@ def test_negative_check_server_ping(setup_katello_service_stop, ansible_module):
         assert "FAIL" in result["stdout"]
 
 
+@capsule
 def test_positive_pre_upgrade_health_check(ansible_module):
     """Verify pre-upgrade health checks
 
@@ -185,6 +189,7 @@ def test_positive_pre_upgrade_health_check(ansible_module):
         assert "FAIL" not in result["stdout"]
 
 
+@capsule
 def test_positive_check_upstream_repository(setup_upstream_repository, ansible_module):
     """Verify upstream repository check
 
@@ -209,6 +214,7 @@ def test_positive_check_upstream_repository(setup_upstream_repository, ansible_m
         assert result["rc"] == 0
 
 
+@capsule
 def test_positive_available_space(ansible_module):
     """Verify available-space check
 
@@ -258,6 +264,7 @@ def test_positive_automate_bz1632768(setup_hammer_defaults, ansible_module):
         assert result["rc"] == 0
 
 
+@capsule
 def test_positive_puppet_check_no_empty_cert_requests(ansible_module):
     """Verify puppet-check-no-empty-cert-requests
 
@@ -282,6 +289,7 @@ def test_positive_puppet_check_no_empty_cert_requests(ansible_module):
         assert result["rc"] == 0
 
 
+@capsule
 def test_positive_puppet_check_empty_cert_requests(setup_puppet_empty_cert, ansible_module):
     """Verify puppet-check-no-empty-cert-requests
 
@@ -314,6 +322,7 @@ def test_positive_puppet_check_empty_cert_requests(setup_puppet_empty_cert, ansi
     assert contacted.values()[0]["matched"] == 0
 
 
+@capsule
 def test_positive_check_hotfix_installed(setup_hotfix_check, setup_install_pkgs, ansible_module):
     """Verify check-hotfix-installed check.
 
@@ -343,6 +352,7 @@ def test_positive_check_hotfix_installed(setup_hotfix_check, setup_install_pkgs,
         assert result["rc"] == 1
 
 
+@capsule
 def test_positive_check_hotfix_installed_without_hotfix(setup_install_pkgs, ansible_module):
     """Verify check-hotfix-installed check.
 
@@ -366,6 +376,7 @@ def test_positive_check_hotfix_installed_without_hotfix(setup_install_pkgs, ansi
         assert result["rc"] == 0
 
 
+@capsule
 def test_positive_check_yum_exclude_list(setup_yum_exclude, ansible_module):
     """Verify check-yum-exclude-list
 
@@ -393,6 +404,7 @@ def test_positive_check_yum_exclude_list(setup_yum_exclude, ansible_module):
         assert result["rc"] == 1
 
 
+@capsule
 def test_positive_check_yum_exclude_list_without_excludes(ansible_module):
     """Verify check-yum-exclude-list.
 
@@ -514,6 +526,7 @@ def test_positive_check_old_foreman_tasks(setup_old_foreman_tasks, ansible_modul
         assert result["rc"] == 0
 
 
+@capsule
 def test_positive_check_tmout_variable(ansible_module):
     """Verify check-tmout-variable. Upstream issue #23430.
 

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -1,8 +1,10 @@
+from testfm.decorators import capsule
 from testfm.decorators import starts_in
 from testfm.log import logger
 from testfm.packages import Packages
 
 
+@capsule
 def test_positive_fm_packages_lock(ansible_module):
     """Verify whether satellite related packages get locked
 
@@ -69,6 +71,7 @@ def test_positive_fm_packages_lock(ansible_module):
         assert result["rc"] == 0
 
 
+@capsule
 @starts_in(6.6)
 def test_positive_lock_package_versions(ansible_module):
     """Verify whether satellite related packages get locked
@@ -134,6 +137,7 @@ def test_positive_lock_package_versions(ansible_module):
         assert result["rc"] == 0
 
 
+@capsule
 def test_positive_fm_packages_install(ansible_module, setup_packages_lock_tests):
     """Verify whether packages install/update work as expected.
 

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -60,6 +60,7 @@ def test_positive_foreman_maintain_upgrade_list(ansible_module):
             assert ver in result["stdout_lines"]
 
 
+@capsule
 def test_positive_repositories_validate(setup_install_pkgs, ansible_module):
     """ Test repositories-validate pre-upgrade check is
      skipped when system is subscribed using custom activationkey.


### PR DESCRIPTION
Refs issue #177 - Run tests on capsule as well.

Tests added:

- test_positive_procedure_by_tag_check_migrations
- test_positive_procedure_by_tag_restore_confirmation
- test_positive_foreman_maintain_health_list
- test_positive_foreman_maintain_health_list_tags
- test_positive_list_health_check_by_tags
- test_positive_foreman_maintain_health_check
- test_positive_foreman_maintain_health_check_by_tags
- test_positive_pre_upgrade_health_check
- test_positive_check_upstream_repository
- test_positive_available_space
- test_positive_puppet_check_no_empty_cert_requests
- test_positive_puppet_check_empty_cert_requests
- test_positive_check_hotfix_installed
- test_positive_check_hotfix_installed_without_hotfix
- test_positive_check_yum_exclude_list
- test_positive_check_yum_exclude_list_without_excludes
- test_positive_check_tmout_variable
- test_positive_fm_packages_lock
- test_positive_lock_package_versions
- test_positive_fm_packages_install
- test_positive_repositories_validate
