### PR TITLE
Fixes #179 - Add test for check-tftp-storage check

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -474,3 +474,16 @@ def setup_packages_lock_tests(request, ansible_module):
             assert result["rc"] == 0
 
     request.addfinalizer(teardown_packages_lock_tests)
+
+
+@pytest.fixture(scope="function")
+def setup_tftp_storage(request, ansible_module):
+    """ Setup/Teardown for test_positive_check_tftp_storage"""
+    setup = ansible_module.command("hammer settings set --name token_duration --value 2")
+    assert setup.values()[0]["rc"] == 0
+
+    def teardown_tftp_storage():
+        teardown = ansible_module.command("hammer settings set --name token_duration --value 360")
+        assert teardown.values()[0]["rc"] == 0
+
+    request.addfinalizer(teardown_tftp_storage)


### PR DESCRIPTION
Refs: https://bugzilla.redhat.com/show_bug.cgi?id=1827176#c16

Test result:

```
(env-testfm) [jpathan@jpathan testfm]$ pytest -sv --ansible-host-pattern server --ansible-user root --ansible-inventory testfm/inventory tests/test_health.py -k test_positive_check_tftp_storage 
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-3.6.1, py-1.8.0, pluggy-0.6.0 -- /home/jpathan/projects/env-testfm/bin/python3
cachedir: .pytest_cache
ansible: 2.6.19
rootdir: /home/jpathan/projects/testfm, inifile:
plugins: ansible-2.2.2
collecting ... collected 22 items / 21 deselected

tests/test_health.py::test_positive_check_tftp_storage 2020-09-11 15:30:08,376 - testfm.log - INFO - Running ForemanMaintain::Scenario::FilteredScenario
================================================================================
Clean old Kernel and initramfs files from tftp-boot:                  [FAIL]
There are old initrd and vmlinuz files present in tftp
--------------------------------------------------------------------------------
Continue with step [Remove the files]? (assuming yes)
Remove the files:                                                     [OK]      
--------------------------------------------------------------------------------
Rerunning the check after fix procedure
Clean old Kernel and initramfs files from tftp-boot:                  [OK]
--------------------------------------------------------------------------------
2020-09-11 15:30:54,877 - testfm.log - INFO - Running ForemanMaintain::Scenario::FilteredScenario
================================================================================
Clean old Kernel and initramfs files from tftp-boot:                  [OK]
--------------------------------------------------------------------------------
PASSED

================== 1 passed, 21 deselected in 311.77 seconds ===================

```