### PR TITLE
Fixes #191 and #178 - Add test for check-postgresql-checkpoint-segments and env-proxy check.

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -592,7 +592,7 @@ def test_positive_check_tftp_storage(ansible_module, setup_tftp_storage):
         4. Assert that check deletes files older than token_duration setting.
         5. Delete all files from /var/lib/tftpboot/boot/
         6. Run foreman-maintain health check --label check-tftp-storage.
-        7. Assert that check-tmout-variable pass.
+        7. Assert that check-tftp-storage pass.
 
     :expectedresults: check-tftp-storage should work.
 
@@ -632,6 +632,75 @@ def test_positive_check_tftp_storage(ansible_module, setup_tftp_storage):
         ansible_module.file(path=f"/var/lib/tftpboot/boot/{file}", state="absent")
     # Re-run check with no files present in /var/lib/tftpboot/boot/
     contacted = ansible_module.command(Health.check(["--label", "check-tftp-storage"]))
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "FAIL" not in result["stdout"]
+        assert result["rc"] == 0
+
+
+def test_positive_check_postgresql_checkpoint_segments(ansible_module):
+    """Verify check-postgresql-checkpoint-segments
+
+    :id: 963a5b47-168a-4443-9fdf-bba59c9b0e97
+
+    :setup:
+        1. foreman-maintain should be installed.
+
+    :steps:
+        1. Add config_entries section in /etc/foreman-installer/custom-hiera.yaml
+        2. Run foreman-maintain health check --label check-postgresql-checkpoint-segments.
+        3. Assert that check-postgresql-checkpoint-segments fails.
+        4. Add checkpoint_segments parameter in /etc/foreman-installer/custom-hiera.yaml
+        5. Run foreman-maintain health check --label check-postgresql-checkpoint-segments.
+        6. Assert that check-postgresql-checkpoint-segments fails.
+        7. Remove config_entries section from /etc/foreman-installer/custom-hiera.yaml
+        8. Run foreman-maintain health check --label check-postgresql-checkpoint-segments.
+        9. Assert that check-postgresql-checkpoint-segments pass.
+
+    :expectedresults: check-postgresql-checkpoint-segments should work.
+
+    :CaseImportance: Critical
+    """
+    # Add config_entries section
+    ansible_module.blockinfile(
+        path="/etc/foreman-installer/custom-hiera.yaml",
+        block="postgresql::server::config_entries:",
+    )
+    # Run check-postgresql-checkpoint-segments check.
+    contacted = ansible_module.command(
+        Health.check(["--label", "check-postgresql-checkpoint-segments"])
+    )
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "ERROR: 'postgresql::server::config_entries' cannot be null." in result["stdout"]
+        assert "Please remove it from following file and re-run the command." in result["stdout"]
+        assert "FAIL" in result["stdout"]
+        assert result["rc"] == 1
+    # Add checkpoint_segments
+    ansible_module.blockinfile(
+        path="/etc/foreman-installer/custom-hiera.yaml",
+        block="postgresql::server::config_entries: \n  checkpoint_segments: 32",
+    )
+    # Run check-postgresql-checkpoint-segments check.
+    contacted = ansible_module.command(
+        Health.check(["--label", "check-postgresql-checkpoint-segments"])
+    )
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "ERROR: Tuning option 'checkpoint_segments' found." in result["stdout"]
+        assert "Please remove it from following file and re-run the command." in result["stdout"]
+        assert "FAIL" in result["stdout"]
+        assert result["rc"] == 1
+    # Remove config_entries section
+    ansible_module.blockinfile(
+        path="/etc/foreman-installer/custom-hiera.yaml",
+        block="postgresql::server::config_entries: \n  checkpoint_segments: 32",
+        state="absent",
+    )
+    # Run check-postgresql-checkpoint-segments check.
+    contacted = ansible_module.command(
+        Health.check(["--label", "check-postgresql-checkpoint-segments"])
+    )
     for result in contacted.values():
         logger.info(result["stdout"])
         assert "FAIL" not in result["stdout"]


### PR DESCRIPTION
Refs: https://bugzilla.redhat.com/show_bug.cgi?id=1867753#c4 
Fixes #191 

Test result: 
```
$ pytest -sv --ansible-host-pattern server --ansible-user root --ansible-inventory testfm/inventory tests/test_health.py -k test_positive_check_postgresql_checkpoint_segments 
============================= test session starts ==============================
platform linux -- Python 3.6.8, pytest-3.6.1, py-1.8.0, pluggy-0.6.0 -- /home/jpathan/projects/env-testfm/bin/python3
cachedir: .pytest_cache
ansible: 2.6.19
rootdir: /home/jpathan/projects/testfm, inifile:
plugins: ansible-2.2.2
collecting ... collected 23 items / 22 deselected

tests/test_health.py::test_positive_check_postgresql_checkpoint_segments 2020-09-21 16:11:44,544 - testfm.log - INFO - Running ForemanMaintain::Scenario::FilteredScenario
================================================================================
Check if checkpoint_segments configuration exists on the system:      [FAIL]
ERROR: 'postgresql::server::config_entries' cannot be null.
Please remove it from following file and re-run the command.
- /etc/foreman-installer/custom-hiera.yaml

--------------------------------------------------------------------------------
Scenario [ForemanMaintain::Scenario::FilteredScenario] failed.

The following steps ended up in failing state:

  [check-postgresql-checkpoint-segments]

Resolve the failed steps and rerun
the command. In case the failures are false positives,
use --whitelist="check-postgresql-checkpoint-segments"
2020-09-21 16:12:00,086 - testfm.log - INFO - Running ForemanMaintain::Scenario::FilteredScenario
================================================================================
Check if checkpoint_segments configuration exists on the system:      [FAIL]
ERROR: Tuning option 'checkpoint_segments' found.
This option is no longer valid for PostgreSQL 9.5 or newer.
Please remove it from following file and re-run the command.
- /etc/foreman-installer/custom-hiera.yaml
The presence of checkpoint_segments in /etc/foreman-installer/custom-hiera.yaml indicates manual tuning.
Manual tuning can override values provided by the --tuning parameter.
Review /etc/foreman-installer/custom-hiera.yaml for values that are already provided by the built in tuning profiles.
Built in tuning profiles also provide a supported upgrade path.

--------------------------------------------------------------------------------
Scenario [ForemanMaintain::Scenario::FilteredScenario] failed.

The following steps ended up in failing state:

  [check-postgresql-checkpoint-segments]

Resolve the failed steps and rerun
the command. In case the failures are false positives,
use --whitelist="check-postgresql-checkpoint-segments"
2020-09-21 16:12:15,465 - testfm.log - INFO - Running ForemanMaintain::Scenario::FilteredScenario
================================================================================
Check if checkpoint_segments configuration exists on the system:      [OK]
--------------------------------------------------------------------------------
PASSED

=================== 1 passed, 22 deselected in 46.89 seconds ===================

```
