### PR TITLE
Fix backup online/offline all tests

### DIFF
--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -395,6 +395,7 @@ def test_positive_satellite_repositories_setup(setup_subscribe_to_cdn_dogfood, a
             assert repo in result["stdout"]
 
 
+@capsule
 @capsule_only()
 def test_positive_capsule_repositories_setup(setup_subscribe_to_cdn_dogfood, ansible_module):
     """Verify that all required capsule repositories gets enabled.

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -300,14 +300,21 @@ def test_positive_backup_online_all(setup_backup_tests, ansible_module):
     """
     subdir = "{}backup-{}".format(BACKUP_DIR, gen_string("alpha"))
     ansible_module.file(path=subdir, state="directory", mode="0777")
-    setup = ansible_module.command(Backup.run_online_backup(["-y", "/mnt/"]))
+    setup = ansible_module.command(Backup.run_online_backup(["-y", subdir]))
     for result in setup.values():
         logger.info(result["stdout"])
         assert "FAIL" not in result["stdout"]
         assert result["rc"] == 0
+    contacted = ansible_module.command("ls {}".format(subdir))
+    source_dir = contacted.values()[0]["stdout_lines"][0]
     contacted = ansible_module.command(
         Backup.run_online_backup(
-            ["-y -f -s -p -t 10M -i", "/mnt/", "--features", "dns,tftp,openscap,dhcp", subdir]
+            [
+                "-y -f -s -p -t 10M -i",
+                "{}/{}".format(subdir, source_dir),
+                "--features dns,tfp,dhcp,openscap",
+                subdir,
+            ]
         )
     )
     for result in contacted.values():
@@ -608,16 +615,18 @@ def test_positive_backup_offline_all(setup_backup_tests, ansible_module):
     """
     subdir = "{}backup-{}".format(BACKUP_DIR, gen_string("alpha"))
     ansible_module.file(path=subdir, state="directory", mode="0777")
-    setup = ansible_module.command(Backup.run_offline_backup(["-y", "/mnt/"]))
+    setup = ansible_module.command(Backup.run_offline_backup(["-y", subdir]))
     for result in setup.values():
         logger.info(result["stdout"])
         assert "FAIL" not in result["stdout"]
         assert result["rc"] == 0
+    contacted = ansible_module.command("ls {}".format(subdir))
+    source_dir = contacted.values()[0]["stdout_lines"][0]
     contacted = ansible_module.command(
         Backup.run_offline_backup(
             [
                 "-y -f -s -p -t 10M -i",
-                "/mnt/",
+                "{}/{}".format(subdir, source_dir),
                 "--features dns,tfp,dhcp,openscap",
                 "--include-db-dumps",
                 subdir,


### PR DESCRIPTION
Test results:
```
$ pytest -sv --ansible-host-pattern server --ansible-user root --ansible-inventory testfm/inventory tests/test_backup.py -k test_positive_backup_offline_all
============================= test session starts ==============================
collecting ... 0
0
collected 20 items / 19 deselected
PASSED

================== 1 passed, 19 deselected in 317.94 seconds ===================
```
```
$ pytest -sv --ansible-host-pattern server --ansible-user root --ansible-inventory testfm/inventory tests/test_backup.py -k test_positive_backup_online_all
============================= test session starts ==============================
collecting ... 0
0
collected 20 items / 19 deselected
PASSED

================== 1 passed, 19 deselected in 240.71 seconds ===================

```