### PR TITLE
Fix test test_positive_foreman_maintain_upgrade_list

### DIFF
--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -25,8 +25,10 @@ def test_positive_foreman_maintain_upgrade_list(ansible_module):
         satellite_version = ansible_module.command(
             "rpm -q 'satellite' --queryformat='%{VERSION}'"
         ).values()[0]["stdout"]
-        if satellite_version.startswith("6.8"):
-            versions = ["6.8.z"]
+        if satellite_version.startswith("6.9"):
+            versions = ["6.9.z"]
+        elif satellite_version.startswith("6.8"):
+            versions = ["6.8.z", "6.9"]
         elif satellite_version.startswith("6.7"):
             versions = ["6.7.z", "6.8"]
         elif satellite_version.startswith("6.6"):
@@ -40,17 +42,19 @@ def test_positive_foreman_maintain_upgrade_list(ansible_module):
         elif satellite_version.startswith("6.2"):
             versions = ["6.2.z", "6.3"]
         else:
-            versions = ["6.2"]
+            versions = ["unsupported satellite version"]
     else:
         capsule_version = ansible_module.command(
             "rpm -q 'satellite-capsule' --queryformat='%{VERSION}'"
         ).values()[0]["stdout"]
-        if capsule_version.startswith("6.8"):
-            versions = ["6.8.z"]
+        if capsule_version.startswith("6.9"):
+            versions = ["6.9.z"]
+        elif capsule_version.startswith("6.8"):
+            versions = ["6.8.z", "6.9"]
         elif capsule_version.startswith("6.7"):
             versions = ["6.7.z", "6.8"]
         else:
-            return "unsupported capsule version"
+            versions = ["unsupported capsule version"]
 
     contacted = ansible_module.command(Upgrade.list_versions())
     for result in contacted.values():


### PR DESCRIPTION
**Test Results:**

**Satellite**:
```
(.testfm) [gtalreja@gtalreja testfm]$ pytest -sv --ansible-host-pattern server --ansible-user=root --ansible-inventory testfm/inventory tests/test_upgrade.py::test_positive_foreman_maintain_upgrade_list --pdb
===================================================== test session starts =====================================================
platform linux -- Python 3.8.6, pytest-3.6.1, py-1.9.0, pluggy-0.6.0 -- /home/gtalreja/sat_workspace/testfm/.testfm/bin/python3
cachedir: .pytest_cache
ansible: 2.6.19
rootdir: /home/gtalreja/sat_workspace/testfm, inifile:
plugins: ansible-2.2.2
collected 1 item

tests/test_upgrade.py::test_positive_foreman_maintain_upgrade_list 0
2020-12-23 20:10:44,883 - testfm.log - INFO - Checking for new version of satellite-maintain...
Nothing to update, can't find new version of satellite-maintain.
6.9.z
PASSED

================================================== 1 passed in 27.33 seconds ==================================================
```
**Capsule:**
```
(.testfm) [gtalreja@gtalreja testfm]$ pytest -sv --ansible-host-pattern capsule --ansible-user=root --ansible-inventory testfm/inventory tests/test_upgrade.py::test_positive_foreman_maintain_upgrade_list
===================================================== test session starts =====================================================
platform linux -- Python 3.8.6, pytest-3.6.1, py-1.9.0, pluggy-0.6.0 -- /home/gtalreja/sat_workspace/testfm/.testfm/bin/python3
cachedir: .pytest_cache
ansible: 2.6.19
rootdir: /home/gtalreja/sat_workspace/testfm, inifile:
plugins: ansible-2.2.2
collected 1 item

tests/test_upgrade.py::test_positive_foreman_maintain_upgrade_list 1
2020-12-23 20:09:23,772 - testfm.log - INFO - Checking for new version of satellite-maintain...
Nothing to update, can't find new version of satellite-maintain.
There are no enabled repos.
 Run "yum repolist all" to see the repos you have.
 To enable Red Hat Subscription Management repositories:
     subscription-manager repos --enable <repo>
 To enable custom repositories:
     yum-config-manager --enable <repo>
6.9.z
PASSED

================================================== 1 passed in 29.25 seconds ==================================================

```
Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>