### PR TITLE
Add stubbed test for BZ-1847889

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -746,3 +746,30 @@ def test_positive_check_env_proxy(ansible_module):
         logger.info(result["stdout"])
         assert "FAIL" not in result["stdout"]
         assert result["rc"] == 0
+
+
+@stubbed
+def test_positive_check_foreman_proxy_verify_dhcp_config_syntax(ansible_module):
+    """Verify foreman-proxy-verify-dhcp-config-syntax
+
+    :id: 43ca5cc7-9888-490d-b1ba-f3298e737039
+
+    :setup:
+        1. foreman-maintain should be installed.
+        2. Satellite instance configured with external DHCP like Infoblox,
+           which has `:use_provider: dhcp_infoblox` set in /etc/foreman-proxy/settings.d/dhcp.yml
+        3. Satellite instance which is DHCP enabled and has `:use_provider: dhcp_isc`
+           set in /etc/foreman-proxy/settings.d/dhcp.yml
+
+    :steps:
+        1. foreman-maintain health list | grep foreman-proxy-verify-dhcp-config-syntax
+        2. foreman-maintain health check --label foreman-proxy-verify-dhcp-config-syntax
+
+    :BZ: 1847889
+
+    :expectedresults: Check is not available on the satellite instances where `:use_provider:`
+                      is set other than `dhcp_isc`, and also not on DHCP disabled Satellite.
+
+
+    :CaseImportance: Medium
+    """

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -355,7 +355,7 @@ def test_positive_check_hotfix_installed(setup_hotfix_check, setup_install_pkgs,
         assert "WARNING" in result["stdout"]
         assert "hotfix-package" in result["stdout"]
         assert setup_hotfix_check in result["stdout"]
-        assert result["rc"] == 1
+        assert result["rc"] == 78
 
 
 @capsule


### PR DESCRIPTION
**Description:**
1. Added stubbed test for [BZ-1847889](https://bugzilla.redhat.com/show_bug.cgi?id=1847889)
2. Fix test `test_positive_check_hotfix_installed` by replacing exit code for warning with 78, Changes from https://projects.theforeman.org/issues/29699

**Test Results:**
```
$ pytest --ansible-host-pattern server --ansible-user=root --ansible-inventory testfm/inventory tests/test_health.py::test_positive_check_hotfix_installed -sq
2021-01-04 14:46:58,928 - testfm.log - INFO - Running preparation steps required to run the next scenarios
================================================================================
Check whether system has any non Red Hat repositories (e.g.: EPEL) enabled:
                                                                      [SKIPPED]
--------------------------------------------------------------------------------


Running ForemanMaintain::Scenario::FilteredScenario
================================================================================
Check to verify if any hotfix installed on system:
/ Checking for presence of hotfix(es). It may take some time to verify.
                                                                      [WARNING]

HOTFIX rpm(s) applied on this system:
hotfix-package-1.0.0-1.HOTFIX.noarch

Found 1 file(s) modified on this system.
/opt/theforeman/tfm/root/usr/share/gems/gems/fog-vsphere-3.4.0/lib/fog/vsphere/requests/compute/list_clusters.rb

*** WARNING: Before update make sure the updated packages contain the listed modifications
*** otherwise these fixes will be lost.
*** It is also recommended to backup the modified files prior update.
--------------------------------------------------------------------------------
Scenario [ForemanMaintain::Scenario::FilteredScenario] failed.

The following steps ended up in warning state:

  [check-hotfix-installed]

The steps in warning state itself might not mean there is an error,
but it should be reviewed to ensure the behavior is expected
.2021-01-04 14:47:16,647 - testfm.log - INFO - Running preparation steps required to run the next scenarios
================================================================================
Check if tooling for package locking is installed:                    [OK]
--------------------------------------------------------------------------------


Running unlocking of package versions
================================================================================
Unlock packages:                                                      [OK]
--------------------------------------------------------------------------------
2021-01-04 14:47:56,989 - testfm.log - INFO - Running preparation steps required to run the next scenarios
================================================================================
Check if tooling for package locking is installed:                    [OK]
--------------------------------------------------------------------------------


Running locking of package versions
================================================================================
Lock packages:                                                        [OK]
--------------------------------------------------------------------------------

1 passed in 279.19 seconds
```