### PR TITLE
Add qe-test-coverage for BZ-1900575, 1905801 and 1886031

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -239,6 +239,28 @@ def test_positive_available_space(ansible_module):
         assert result["rc"] == 0
 
 
+def test_positive_available_space_candlepin(ansible_module):
+    """Verify available-space-cp check
+
+    :id: 382a2bf3-a3da-4e46-b370-a443450f93b7
+
+    :setup:
+        1. foreman-maintain should be installed.
+
+    :steps:
+        1. Run foreman-maintain health check --label available-space-cp
+
+    :expectedresults: Health check should perform.
+
+    :CaseImportance: Medium
+    """
+    contacted = ansible_module.command(Health.check({"label": "available-space-cp"}))
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "FAIL" not in result["stdout"]
+        assert result["rc"] == 0
+
+
 def test_positive_automate_bz1632768(setup_hammer_defaults, ansible_module):
     """Verify that health check is performed when
      hammer on system have defaults set.

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -282,3 +282,37 @@ def test_positive_fm_service_restart_bz_1696862(setup_bz_1696862, ansible_module
         logger.info(result["stdout"])
         assert "FAIL" not in result["stdout"]
         assert result["rc"] == 0
+
+
+@capsule
+def test_positive_foreman_maintain_service_list_sidekiq(ansible_module):
+    """List sidekiq services with service list
+
+    :id: 5acb68a9-c430-485d-bb45-b499adc90927
+
+    :setup:
+        1. foreman-maintain should be installed.
+
+    :steps:
+        1. Run foreman-maintain service list
+        2. Run foreman-maintain service restart
+
+    :expectedresults: Sidekiq-services should list and should restart.
+
+    :CaseImportance: Medium
+    """
+    contacted = ansible_module.command(Service.service_list())
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "FAIL" not in result["stdout"]
+        assert result["rc"] == 0
+        assert "dynflow-sidekiq@.service" in result["stdout"]
+
+    contacted = ansible_module.command(Service.service_restart())
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "FAIL" not in result["stdout"]
+        assert result["rc"] == 0
+        assert "dynflow-sidekiq@orchestrator" in result["stdout"]
+        assert "dynflow-sidekiq@worker" in result["stdout"]
+        assert "dynflow-sidekiq@worker-hosts-queue" in result["stdout"]

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,4 +1,5 @@
 from testfm.decorators import capsule
+from testfm.decorators import stubbed
 from testfm.helpers import product
 from testfm.helpers import server
 from testfm.log import logger
@@ -103,6 +104,8 @@ def test_positive_repositories_validate(setup_install_pkgs, ansible_module):
         assert skip_message in result["stdout"]
 
 
+@capsule
+@stubbed
 def test_positive_self_update():
     """ Test self-update foreman-maintain package feature.
 
@@ -121,6 +124,33 @@ def test_positive_self_update():
         :expectedresults:
             1. It updates FM to latest version and gives message to re-run command.
             2. If disable-self-upgrade option is used then it should skip self-upgrade step.
+
+        :CaseImportance: Critical
+        """
+
+
+@capsule
+@stubbed
+def test_positive_check_presence_satellite_or_satellite_capsule():
+    """ Check for presence of satellite or satellite-capsule packages feature.
+
+        :id: 1011ff01-6dfb-422f-92c5-995d38bc163e
+
+        :setup:
+            1. foreman-maintain should be installed.
+            2. foreman-maintain package version should be >= v0.6.x
+
+        :steps:
+            1. Run foreman-maintain upgrade list-versions/check/run command.
+            2. Run foreman-maintain upgrade list-versions/check/run command,
+                after removing satellite and satellite-capsule packages.
+
+        :BZ: 1886031
+
+        :expectedresults:
+            1. If those packages are removed, then it should give error, like
+                "Error: Important rpm package satellite/satellite-capsule is not installed!
+                 Install satellite/satellite-capsule rpm to ensure system consistency."
 
         :CaseImportance: Critical
         """


### PR DESCRIPTION
**Test Results:**
```
$ pytest -sv --junit-xml=foreman-results.xml --ansible-host-pattern server --ansible-user root --ansible-inventory ../testfm/inventory test_health.py -k test_positive_available_space_candlepin
========================================================== test session starts ==========================================================
platform linux -- Python 3.7.7, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/gtalreja/sat_workspace/testfm/.testfm/bin/python
cachedir: ../.pytest_cache
ansible: 2.6.19
rootdir: /home/gtalreja/sat_workspace/testfm, inifile:
plugins: ansible-2.2.2
collected 25 items / 24 deselected                                                                                                      

test_health.py::test_positive_available_space_candlepin 2021-03-15 15:24:51,505 - testfm.log - INFO - Running ForemanMaintain::Scenario::FilteredScenario
================================================================================
Check to make sure /var/lib/candlepin has enough space:               [OK]
--------------------------------------------------------------------------------
PASSED

--------------------------- generated xml file: /home/gtalreja/sat_workspace/testfm/tests/foreman-results.xml ---------------------------
=============================================== 1 passed, 24 deselected in 18.16 seconds ================================================
```
```
$ pytest -sqv --junit-xml=foreman-results.xml --ansible-host-pattern server --ansible-user root --ansible-inventory testfm/inventory tests/test_service.py -k test_positive_foreman_maintain_service_list_sidekiq
========================================================== test session starts ==========================================================
platform linux -- Python 3.7.7, pytest-3.6.1, py-1.10.0, pluggy-0.6.0
ansible: 2.6.19
rootdir: /home/gtalreja/sat_workspace/testfm, inifile:
plugins: ansible-2.2.2
collected 11 items / 10 deselected                                                                                                      

tests/test_service.py 2021-03-15 15:29:55,264 - testfm.log - INFO - Running Service List
================================================================================
List applicable services: 
dynflow-sidekiq@.service                      enabled 
foreman-proxy.service                         enabled 
httpd.service                                 enabled 
postgresql.service                            enabled 
pulp_celerybeat.service                       enabled 
pulp_resource_manager.service                 enabled 
pulp_streamer.service                         enabled 
pulp_workers.service                          enabled 
puppetserver.service                          enabled 
qdrouterd.service                             enabled 
qpidd.service                                 enabled 
rh-mongodb34-mongod.service                   enabled 
rh-redis5-redis.service                       enabled 
smart_proxy_dynflow_core.service              enabled 
squid.service                                 enabled 
tomcat.service                                enabled

All services listed                                                   [OK]
--------------------------------------------------------------------------------
2021-03-15 15:32:33,402 - testfm.log - INFO - Running Restart Services
================================================================================
Check if command is run as root user:                                 [OK]
--------------------------------------------------------------------------------
Restart applicable services: 

Stopping the following service(s):
rh-mongodb34-mongod, postgresql, qdrouterd, qpidd, rh-redis5-redis, squid, pulp_celerybeat, pulp_resource_manager, pulp_streamer, pulp_workers, smart_proxy_dynflow_core, tomcat, dynflow-sidekiq@orchestrator, httpd, puppetserver, dynflow-sidekiq@worker, dynflow-sidekiq@worker-hosts-queue, foreman-proxy
/ All services stopped                                                          

Starting the following service(s):
rh-mongodb34-mongod, postgresql, qdrouterd, qpidd, rh-redis5-redis, squid, pulp_celerybeat, pulp_resource_manager, pulp_streamer, pulp_workers, smart_proxy_dynflow_core, tomcat, dynflow-sidekiq@orchestrator, httpd, puppetserver, dynflow-sidekiq@worker, dynflow-sidekiq@worker-hosts-queue, foreman-proxy
- All services started                                                [OK]      
--------------------------------------------------------------------------------
.

------------------------------ generated xml file: /home/gtalreja/sat_workspace/testfm/foreman-results.xml ------------------------------
=============================================== 1 passed, 10 deselected in 168.30 seconds ===============================================
```

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>