### PR TITLE
qe_test_coverage bz1762302

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -817,4 +817,5 @@ def test_positive_remove_job_file(setup_subscribe_to_cdn_dogfood, ansible_module
     """
     contacted = ansible_module.command(Health.check({"label": "disk" "-performance"}))
     contacted = ansible_module.find(paths="/var/lib/pulp", file_type="file")
-    assert "job" not in contacted.values()[0]["files"][0]["path"]
+    for file in contacted.values()[0]["files"]:
+        assert "job" not in file["path"]

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -796,3 +796,25 @@ def test_positive_check_foreman_proxy_verify_dhcp_config_syntax(ansible_module):
 
     :CaseImportance: Medium
     """
+
+
+def test_positive_remove_job_file(setup_subscribe_to_cdn_dogfood, ansible_module):
+    """Verify file /var/lib/pulp/job1.0.0 is not present after the following command.
+
+    :id: eed224f9-a2ec-4d15-9047-cede0b823866
+
+    :setup:
+        1. foreman-maintain should be installed.
+
+    :steps:
+        1. Run foreman-maintain health check --label disk-performance
+
+    :expectedresults: /var/lib/pulp/job1.0.0 file should not exist.
+
+    :CaseImportance: Medium
+
+    :BZ: 1762302
+    """
+    contacted = ansible_module.command(Health.check({"label": "disk" "-performance"}))
+    contacted = ansible_module.find(paths="/var/lib/pulp", file_type="file")
+    assert "job" not in contacted.values()[0]["files"][0]["path"]


### PR DESCRIPTION
```
$ pytest -sv --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory tests/test_health.py::test_positive_remove_job_file
========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.8.7, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/akjha/satelliteQE/testfm_env/bin/python
cachedir: .pytest_cache
ansible: 2.6.19
rootdir: /home/akjha/satelliteQE/testfm, inifile:
plugins: ansible-2.2.2
collected 1 item                                                                                                                                                                                                                         

tests/test_health.py::test_positive_remove_job_file PASSED


======================================================================================================= 1 passed in 173.86 seconds =======================================================================================================
```