### PR TITLE
Adding support and tests for pulp3 migration related subcommands.

### DIFF
--- a/testfm/constants.py
+++ b/testfm/constants.py
@@ -8,6 +8,8 @@ DOGFOOD_ACTIVATIONKEY = settings.subscription.dogfood_activationkey
 CAPSULE_DOGFOOD_ACTIVATIONKEY = settings.subscription.capsule_dogfood_activationkey
 DOGFOOD_URL = settings.subscription.dogfood_url
 HOTFIX_URL = settings.testfm.hotfix_url
+REPOS_HOSTING_URL = settings.robottelo.repos_hosting_url
+FAKE_YUM0_REPO = f"{REPOS_HOSTING_URL}/fake_yum0/"
 
 katello_ca_consumer = DOGFOOD_URL + "/pub/katello-ca-consumer-latest.noarch.rpm"
 upstream_url = {

--- a/testfm/content.py
+++ b/testfm/content.py
@@ -1,0 +1,91 @@
+# -*- encoding: utf-8 -*-
+"""
+Usage:
+    satellite-maintain content [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters:
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands:
+    prepare                       Prepare content for Pulp 3
+    prepare-abort                 Abort all running Pulp 2 to Pulp 3 migration tasks
+    migration-stats               Retrieve Pulp 2 to Pulp 3 migration statistics
+    migration-reset               Reset the Pulp 2 to Pulp 3 migration data (pre-switchover)
+    remove-pulp2                  Remove pulp2 and mongodb packages and data
+
+Options:
+    -h, --help                    print help
+"""
+from testfm.base import Base
+
+
+class Content(Base):
+    """Manipulates Foreman-maintain's content command"""
+
+    command_base = "content"
+
+    @classmethod
+    def prepare(cls, options=None):
+        """Build foreman-maintain content prepare"""
+
+        cls.command_sub = "prepare"
+
+        if options is None:
+            options = {}
+
+        result = cls._construct_command(options)
+
+        return result
+
+    @classmethod
+    def prepare_abort(cls, options=None):
+        """Build foreman-maintain content prepare-abort"""
+
+        cls.command_sub = "prepare-abort"
+
+        if options is None:
+            options = {}
+
+        result = cls._construct_command(options)
+
+        return result
+
+    @classmethod
+    def migration_stats(cls, options=None):
+        """Build foreman-maintain content migration-stats"""
+
+        cls.command_sub = "migration-stats"
+
+        if options is None:
+            options = {}
+
+        result = cls._construct_command(options)
+
+        return result
+
+    @classmethod
+    def migration_reset(cls, options=None):
+        """Build foreman-maintain content migration-reset"""
+
+        cls.command_sub = "migration-reset"
+
+        if options is None:
+            options = {}
+
+        result = cls._construct_command(options)
+
+        return result
+
+    @classmethod
+    def remove_pulp2(cls, options=None):
+        """Build foreman-maintain content remove-pulp2"""
+
+        cls.command_sub = "remove-pulp2"
+
+        if options is None:
+            options = {}
+
+        result = cls._construct_command(options)
+
+        return result

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,0 +1,52 @@
+from testfm.content import Content
+from testfm.log import logger
+
+
+def test_positive_content_migrate(ansible_module, setup_yum_content):
+    """Verify that pulp2 to pulp3 content migration subcommands work properly.
+
+    :id: 71836e91-3bfa-4867-ac6f-16f29cf37d52
+
+    :setup:
+        1. foreman-maintain should be installed.
+        2. Yum content synced via fixture.
+
+    :steps:
+        1. Run prep-6.10-upgrade
+        2. Migrate content to Pulp 3
+        3. Check migration statistics
+        4. Reset the migration data
+        5. Check migration statistics again
+
+    :expectedresults: Successful run.
+
+    :CaseImportance: High
+    """
+    contacted = ansible_module.command("foreman-maintain prep-6.10-upgrade")
+    assert contacted.values()[0]["rc"] == 0
+
+    contacted = ansible_module.command(Content.prepare())
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "FAIL" not in result["stdout"]
+        assert result["rc"] == 0
+
+    contacted = ansible_module.command(Content.migration_stats())
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "FAIL" not in result["stdout"]
+        assert result["rc"] == 0
+        assert "Migrated/Total RPMs: 32/32" in result["stdout"]
+
+    contacted = ansible_module.command(Content.migration_reset())
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "FAIL" not in result["stdout"]
+        assert result["rc"] == 0
+
+    contacted = ansible_module.command(Content.migration_stats())
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "FAIL" not in result["stdout"]
+        assert result["rc"] == 0
+        assert "Migrated/Total RPMs: 0/32" in result["stdout"]

--- a/tests/test_prep_6_10_upgrade.py
+++ b/tests/test_prep_6_10_upgrade.py
@@ -1,0 +1,30 @@
+from testfm.log import logger
+
+
+def test_positive_prep_6_10_upgrade(ansible_module):
+    """Runs content directory preparation for pulp3 migration.
+
+    :id: 46531c4a-2276-4ccd-aed7-92c53d1ad267
+
+    :setup:
+        1. foreman-maintain should be installed.
+
+    :steps:
+        1. Create /var/lib/pulp/content directory with root owner and 0000 mode
+        2. Run foreman-maintain prep-6.10-upgrade
+
+    :expectedresults: Owner group and mode should be changed.
+
+    :CaseImportance: High
+    """
+    ansible_module.file(path="/var/lib/pulp/content", state="directory", group="root", mode="0000")
+
+    contacted = ansible_module.command("foreman-maintain prep-6.10-upgrade")
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "FAIL" not in result["stdout"]
+        assert result["rc"] == 0
+
+    contacted = ansible_module.stat(path="/var/lib/pulp/content")
+    assert contacted.values()[0]["stat"]["gr_name"] == "pulp"
+    assert contacted.values()[0]["stat"]["mode"] == "2070"


### PR DESCRIPTION
Just adding some sanity tests and support.

Test result:
```
(venv) [vsedmik@localhost testfm]$ pytest -sv --ansible-host-pattern server --ansible-user=root --ansible-inventory testfm/inventory tests/test_prep_6_10_upgrade.py::test_positive_prep_6_10_upgrade tests/test_content.py::test_positive_content_migrate
=================== test session starts ===================
platform linux -- Python 3.9.5, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/vsedmik/PycharmProjects/testfm/venv/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/vsedmik/PycharmProjects/testfm, inifile:
plugins: ansible-2.2.3
collected 2 items                                                                                                                                                                                                                         
...
================ 2 passed in 287.21 seconds ===============
```
