### PR TITLE
Remove fabric dependency from TestFM

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,8 +37,9 @@ Get the source code and install dependencies::
 
 Before running any tests, you must create a configuration file::
 
-   cp testfm.properties.sample testfm.properties
-   vi testfm.properties
+   cp testfm.sample.yaml testfm.local.yaml
+   OR
+   cp testfm.sample.yaml testfm.yaml
 
 There are a few other things you need to do before continuing:
 
@@ -54,15 +55,15 @@ Before running any tests, you must add foreman or satellite hostname to the
 
 That done, you can run tests using pytest ::
 
-    pytest -sv --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory
+    pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory
     tests/
 
 It is possible to run a specific subset of tests::
 
-    pytest -sv --ansible-host-pattern server --ansible-user=root --ansible-inventory testfm/inventory
+    pytest -v --ansible-host-pattern server --ansible-user=root --ansible-inventory testfm/inventory
     tests/test_case.py
 
-    pytest -sv --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory
+    pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory
     tests/test_case.py::test_case_name
 
 Want to contribute?

--- a/conf/testfm.sample.yaml
+++ b/conf/testfm.sample.yaml
@@ -1,7 +1,7 @@
 # copy this file as `testfm.local.yaml` and override any config provided under `conf/*.yaml`
 # or preferably use environment variables instead of this file
 # example:
-# `export TESTFM_TESTFM__SERVER_HOSTNAME=myserver.example.com`
+# `export TESTFM_TESTFM__HOTFIX_URL=<HOTFIX_URL>`
 ---
 # copy SUBSCRIPTION section from subscription.yaml or keep subscription.yaml under conf/
 # SUBSCRIPTION:
@@ -13,5 +13,4 @@
   # DOGFOOD_ACTIVATIONKEY: <DOGFOOD_ACTIVATIONKEY>
   # CAPSULE_DOGFOOD_ACTIVATIONKEY: <CAPSULE_DOGFOOD_ACTIVATIONKEY>
 # TESTFM:
-  # SERVER_HOSTNAME: <SERVER_HOSTNAME>
   # HOTFIX_URL: <HOTFIX_URL>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,8 +22,9 @@ Get the source code and install dependencies::
 
 Before running any tests, you must create a configuration file::
 
-   cp testfm.properties.sample testfm.properties
-   vi testfm.properties
+   cp testfm.sample.yaml testfm.local.yaml
+   OR
+   cp testfm.sample.yaml testfm.local.yaml
 
 There are a few other things you need to do before continuing:
 
@@ -39,15 +40,15 @@ Before running any tests, you must add foreman or satellite hostname to the
 
 That done, you can run tests using pytest ::
 
-    pytest -sv --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory
+    pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory
     tests/
 
 It is possible to run a specific subset of tests::
 
-    pytest -sv --ansible-host-pattern server --ansible-user=root --ansible-inventory testfm/inventory
+    pytest -v --ansible-host-pattern server --ansible-user=root --ansible-inventory testfm/inventory
     tests/test_case.py
 
-    pytest -sv --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory
+    pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory
     tests/test_case.py::test_case_name
 
 Want to contribute?

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 ansible==2.9.20
 dynaconf==3.1.4
-fabric==2.6.0
 fauxfactory==3.1.0
 pre-commit
 PyNaCl==1.4.0

--- a/testfm/__init__.py
+++ b/testfm/__init__.py
@@ -19,7 +19,6 @@ settings = Dynaconf(
             "subscription.dogfood_activationkey",
             "subscription.capsule_dogfood_activationkey",
             "subscription.dogfood_url",
-            "testfm.server_hostname",
             "testfm.hotfix_url",
             must_exist=True,
         )

--- a/testfm/constants.py
+++ b/testfm/constants.py
@@ -8,7 +8,6 @@ DOGFOOD_ACTIVATIONKEY = settings.subscription.dogfood_activationkey
 CAPSULE_DOGFOOD_ACTIVATIONKEY = settings.subscription.capsule_dogfood_activationkey
 DOGFOOD_URL = settings.subscription.dogfood_url
 HOTFIX_URL = settings.testfm.hotfix_url
-SERVER_HOSTNAME = settings.testfm.server_hostname
 
 katello_ca_consumer = DOGFOOD_URL + "/pub/katello-ca-consumer-latest.noarch.rpm"
 upstream_url = {

--- a/testfm/helpers.py
+++ b/testfm/helpers.py
@@ -1,14 +1,9 @@
 # helpers required for TestFM
 import os
 
-from fabric import Connection
-
-from testfm.constants import SERVER_HOSTNAME
-
 
 def product():
-    """This helper provides Satellite/Capsule version."""
-
+    """This helper provides Satellite/Capsule version"""
     server_version = os.popen(
         "ansible -i testfm/inventory server --user root -m shell "
         '-a "rpm -q satellite > /dev/null && rpm -q satellite --queryformat=%{VERSION}'
@@ -18,14 +13,14 @@ def product():
 
 
 def run(command):
-    """ Use this helper to execute shell command on Satellite"""
-    return Connection(SERVER_HOSTNAME, "root").run(command)
+    """Use this helper to execute shell command on Satellite"""
+    return os.popen("ansible server -i testfm/inventory -m command -a '${command}'").read()
 
 
 def server():
-    """ Use this to find whether server on which tests are running is capsule or satellite."""
-    contacted = run("rpm -q satellite > /dev/null; echo $?")
-    if "0" in contacted.stdout:
+    """Use this to find whether server on which tests are running is capsule or satellite."""
+    result = run("rpm -q satellite")
+    if "rc=0" in result:
         return "satellite"
     else:
         return "capsule"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,6 @@ from testfm.constants import RHN_USERNAME
 from testfm.constants import satellite_answer_file
 from testfm.constants import upstream_url
 from testfm.helpers import product
-from testfm.helpers import run
 from testfm.helpers import server
 from testfm.log import logger
 from testfm.maintenance_mode import MaintenanceMode
@@ -410,7 +409,7 @@ def setup_old_foreman_tasks(ansible_module):
     rake_command = "foreman-rake console <<< "
     find_task = '\'t = ForemanTasks::Task.where(state: "stopped").first;'
     update_task = "t.started_at = t.started_at - 31.day;t.save(:validate => false)'"
-    run(rake_command + find_task + update_task)
+    ansible_module.shell(rake_command + find_task + update_task)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
**Description**:
1. Removing fabric requirement from TestFM.
2. Pytest option `-s` will not be needed to work around fabric config issues.
3. Removing `SERVER_HOSTNAME` setting, as it was used earlier by `fabric.Connection` method.
4. Updating fixture `setup_old_foreman_tasks` to use `ansible_module.shell` to run command, attaching test results.
5. Updating Documentation to use Dynaconf YAML's and to not use `-s` with pytest.

**Test Results:**
```$ pytest -v --ansible-host-pattern server --ansible-user=root --ansible-inventory testfm/inventory tests/test_health.py -k test_positive_check_old_foreman_tasks
========================================================== test session starts ==========================================================
platform linux -- Python 3.8.7, pytest-3.6.1, py-1.9.0, pluggy-0.6.0 -- /home/gtalreja/sat_workspace/testfm/.testfm/bin/python3
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/gtalreja/sat_workspace/testfm, inifile:
plugins: ansible-2.2.3
collected 26 items / 25 deselected

tests/test_health.py::test_positive_check_old_foreman_tasks PASSED                                                                [100%]

=============================================== 1 passed, 25 deselected in 67.45 seconds ================================================
```

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>