### PR TITLE
Fix test test_negative_check_server_ping

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -164,7 +164,7 @@ def test_negative_check_server_ping(setup_katello_service_stop, ansible_module):
 
     :CaseImportance: Critical
     """
-    contacted = ansible_module.command(Health.check({"label": "server-ping"}))
+    contacted = ansible_module.command(Health.check(["--label", "server-ping", "--assumeyes"]))
     for result in contacted.values():
         logger.info(result["stdout"])
         assert "FAIL" in result["stdout"]


### PR DESCRIPTION
**Test Results:**
```
pytest -v --disable-warnings --ansible-host-pattern server --ansible-user root --ansible-inventory testfm/inventory tests/test_health.py -k test_negative_check_server_ping
========================================================== test session starts ==========================================================
platform linux -- Python 3.7.7, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/gtalreja/sat_workspace/testfm/.testfm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/gtalreja/sat_workspace/testfm, inifile:
plugins: ansible-2.2.4
collected 26 items / 25 deselected                                                                                                      

tests/test_health.py::test_negative_check_server_ping PASSED                                                                      [100%]

=============================================== 1 passed, 25 deselected in 228.55 seconds ===============================================
```
This test gets pytest stuck for not getting `--assumeyes` to restart services.

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>