### PR TITLE
Fix versions handling for 6.10 and beyond.

### DIFF
--- a/testfm/decorators.py
+++ b/testfm/decorators.py
@@ -1,3 +1,5 @@
+from distutils.version import StrictVersion as Version
+
 import pytest
 import unittest2
 
@@ -19,11 +21,11 @@ def run_only_on(*server_version):
 
         from TestFM.decorators import run_only_on
 
-        @run_only_on('6.4')
+        @run_only_on("6.4")
         def test_health_check():
             # test code continues here
 
-    :param str server_version: Enter '6.8', 6.7', '6.6', '6.5', '6.4' and '6.3'
+    :param str server_version: Enter "6.8", "6.7", "6.6", "6.5", "6.4" and "6.3"
     for specific version
     """
     prd_version = product()
@@ -43,15 +45,15 @@ def starts_in(version):
 
         from TestFM.decorators import starts_in
 
-        @starts_in(6.6)
+        @starts_in("6.6")
         def test_health_check():
             # test code continues here
 
-    :param float version: Enter 6.8, 6.7, 6.6, 6.5, 6.4 and 6.3
+    :param str version: Enter "6.10", "6.9", "6.8.4", and likewise
     for specific version
     """
     return pytest.mark.skipif(
-        float(product()) < version,
+        Version(product()) < Version(version),
         reason="Server version is '{}' and this test will run only "
         "on {} '{}' onward".format(product(), server(), version),
     )
@@ -66,15 +68,15 @@ def ends_in(version):
 
         from TestFM.decorators import ends_in
 
-        @ends_in(6.6)
+        @ends_in("6.6")
         def test_health_check():
             # test code continues here
 
-    :param float version: Enter 6.7, 6.6, 6.5 , 6.4 , 6.3 , 6.2 and 6.1
+    :param str version: Enter "6.10", "6.9", "6.8.4", and likewise
     for specific version
     """
     return pytest.mark.skipif(
-        float(product()) > version,
+        Version(product()) > Version(version),
         reason="Server version is '{}' and this test will run only "
         "on {} <= '{}'".format(product(), server(), version),
     )

--- a/testfm/helpers.py
+++ b/testfm/helpers.py
@@ -9,7 +9,7 @@ def product():
         '-a "rpm -q satellite > /dev/null && rpm -q satellite --queryformat=%{VERSION}'
         ' || rpm -q satellite-capsule --queryformat=%{VERSION}" -o'
     ).read()
-    return server_version.splitlines()[0].split(" ")[-1][:3]
+    return server_version.splitlines()[0].split(" ")[-1]
 
 
 def run(command):

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -716,7 +716,7 @@ def test_negative_backup_online_incremental_nodir(ansible_module):
         assert NOPREV_MSG in result["stderr"]
 
 
-@ends_in(6.7)
+@ends_in("6.7")
 def test_positive_backup_stopped_dynflowd(setup_backup_tests, ansible_module):
     """Take online backup of server when dynflowd is not running
 
@@ -763,7 +763,7 @@ def test_positive_backup_stopped_dynflowd(setup_backup_tests, ansible_module):
             assert result["rc"] == 0
 
 
-@ends_in(6.7)
+@ends_in("6.7")
 def test_positive_backup_stopped_foreman_tasks(setup_backup_tests, ansible_module):
     """Take online backup of server when foreman-tasks is not running
 

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -73,7 +73,7 @@ def test_positive_fm_packages_lock(ansible_module):
 
 
 @pytest.mark.capsule
-@starts_in(6.6)
+@starts_in("6.6")
 def test_positive_lock_package_versions(ansible_module):
     """Verify whether satellite related packages get locked
 


### PR DESCRIPTION
Originally the version handling was not supposed to work beyond 6.9, it used only the first three characters obtained from the version of the satellite package and casted it to float for comparsion. This way the 6.10 version was considered as 6.1 and some tests targeted to run on versions 6.7 and lower were running (and failing) on 6.10 too.

Fixes point 2. of issue #241 

Test result against Sat 6.10:
```
(venv) [vsedmik@localhost testfm]$ pytest -sv --ansible-host-pattern server --ansible-user=root --ansible-inventory testfm/inventory tests/test_backup.py::test_positive_backup_stopped_dynflowd tests/test_backup.py::test_positive_backup_stopped_foreman_tasks tests/test_packages.py::test_positive_lock_package_versions
=================== test session starts ===================
platform linux -- Python 3.9.5, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/vsedmik/PycharmProjects/testfm/venv/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/vsedmik/PycharmProjects/testfm, inifile:
plugins: ansible-2.2.3
collected 3 items                                                                                                                                                                                                                         

tests/test_backup.py::test_positive_backup_stopped_dynflowd SKIPPED
tests/test_backup.py::test_positive_backup_stopped_foreman_tasks SKIPPED
tests/test_packages.py::test_positive_lock_package_versions Loading callback plugin unnamed of type old, v1.0 from /home/vsedmik/PycharmProjects/testfm/venv/lib64/python3.9/site-packages/pytest_ansible/module_dispatcher/v28.py
...
=================== 1 passed, 2 skipped in 1082.35 seconds ===================