### PR TITLE
Add python3-wheel to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora
 MAINTAINER https://github.com/SatelliteQE
 
 RUN dnf install -y gcc git make cmake libffi-devel openssl-devel python3-devel \
-    python3-pip redhat-rpm-config which libcurl-devel libxml2-devel
+    python3-pip python3-wheel redhat-rpm-config which libcurl-devel libxml2-devel
 
 COPY / /testfm/
 WORKDIR /testfm


### PR DESCRIPTION
Some dependencies don't have wheels on pypi