### PR TITLE
Test fix in sync_plan related tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,7 +212,7 @@ def setup_sync_plan(request, ansible_module):
             sync_yml = yaml.safe_load(f)
             for id in sync_yml:
                 if id["Enabled"]:
-                    sync_ids.append(id["ID"])
+                    sync_ids.append(id["Id"])
         request.addfinalizer(teardown_sync_plan)
         return list(set(sync_ids)), sat_hostname
 


### PR DESCRIPTION
**Test Results**
```
1) pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory tests/test_maintenance_mode.py -k test_positive_maintenance_mode
=============================test session starts =========================================
platform linux -- Python 3.8.8, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/sganar/foreman/fm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/sganar/foreman/testfm, inifile:
plugins: ansible-2.2.3
collected 1 item                                                                                                                                                                                                                          

tests/test_maintenance_mode.py::test_positive_maintenance_mode                                                PASSED                                                                                                                                                               [100%]

=================================1 passed in 543.88 seconds ==============================

2) pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory tests/test_advanced.py -k test_positive_sync_plan_disable_enable
================================ test session starts ========================================
platform linux -- Python 3.8.8, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/sganar/foreman/fm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/sganar/foreman/testfm, inifile:
plugins: ansible-2.2.3
collected 14 items / 13 deselected                                                                                                                                                                                                        

tests/test_advanced.py::test_positive_sync_plan_disable_enable                                                  PASSED                                                                                                                                                               [100%]

======================== 1 passed, 13 deselected in 389.24 seconds ==============================
```