### PR TITLE
Fix expected files for backup

### DIFF
--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -13,8 +13,6 @@ OFFLINE_CAPS_FILES = [
     "config_files.tar.gz",
     ".config.snar",
     "metadata.yml",
-    "mongo_data.tar.gz",
-    ".mongo.snar",
 ]
 
 OFFLINE_SAT_FILES = [
@@ -28,7 +26,7 @@ ONLINE_CAPS_FILES = [
     "config_files.tar.gz",
     ".config.snar",
     "metadata.yml",
-    "mongo_dump",
+    "pulpcore.dump",
 ]
 
 ONLINE_SAT_FILES = [

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -9,18 +9,14 @@ BACKUP_DIR = "/tmp/"
 NODIR_MSG = "ERROR: parameter 'BACKUP_DIR': no value provided"
 NOPREV_MSG = "ERROR: option '--incremental': Previous backup " "directory does not exist"
 
-OFFLINE_CAPS_FILES = [
+
+OFFLINE_BACKUP_FILES = [
     "config_files.tar.gz",
     ".config.snar",
     "metadata.yml",
-]
-
-OFFLINE_SAT_FILES = [
     "pgsql_data.tar.gz",
     ".postgres.snar",
 ]
-
-OFFLINE_BACKUP_FILES = OFFLINE_CAPS_FILES + OFFLINE_SAT_FILES
 
 ONLINE_CAPS_FILES = [
     "config_files.tar.gz",
@@ -349,9 +345,6 @@ def test_positive_backup_offline(setup_backup_tests, ansible_module):
     files_list = contacted.values()[0]["stdout_lines"]
     expected_files = OFFLINE_BACKUP_FILES
 
-    # capsule-specific file list
-    if server() == "capsule":
-        expected_files = OFFLINE_CAPS_FILES
     assert set(files_list).issuperset(expected_files + CONTENT_FILES), assert_msg
 
 
@@ -387,9 +380,6 @@ def test_positive_backup_offline_skip_pulp_content(setup_backup_tests, ansible_m
     files_list = contacted.values()[0]["stdout_lines"]
     expected_files = OFFLINE_BACKUP_FILES
 
-    # capsule-specific file list
-    if server() == "capsule":
-        expected_files = OFFLINE_CAPS_FILES
     assert set(files_list).issuperset(expected_files), assert_msg
     assert CONTENT_FILES not in files_list, "content not skipped"
 
@@ -427,9 +417,6 @@ def test_positive_backup_offline_preserve_directory(setup_backup_tests, ansible_
     files_list = contacted.values()[0]["stdout_lines"]
     expected_files = OFFLINE_BACKUP_FILES
 
-    # capsule-specific file list
-    if server() == "capsule":
-        expected_files = OFFLINE_CAPS_FILES
     assert set(files_list).issuperset(expected_files + CONTENT_FILES), assert_msg
 
 
@@ -465,9 +452,6 @@ def test_positive_backup_offline_split_pulp_tar(setup_backup_tests, ansible_modu
     files_list = contacted.values()[0]["stdout_lines"]
     expected_files = OFFLINE_BACKUP_FILES
 
-    # capsule-specific file list
-    if server() == "capsule":
-        expected_files = OFFLINE_CAPS_FILES
     assert set(files_list).issuperset(expected_files + CONTENT_FILES), assert_msg
 
 
@@ -547,9 +531,6 @@ def test_positive_backup_offline_capsule_features(setup_backup_tests, ansible_mo
     files_list = contacted.values()[0]["stdout_lines"]
     expected_files = OFFLINE_BACKUP_FILES
 
-    # capsule-specific file list
-    if server() == "capsule":
-        expected_files = OFFLINE_CAPS_FILES
     assert set(files_list).issuperset(expected_files + CONTENT_FILES), assert_msg
 
 
@@ -586,7 +567,7 @@ def test_positive_backup_offline_logical(setup_backup_tests, ansible_module):
 
     # capsule-specific file list
     if server() == "capsule":
-        expected_files = OFFLINE_CAPS_FILES + ONLINE_CAPS_FILES
+        expected_files = OFFLINE_BACKUP_FILES + ONLINE_CAPS_FILES
     assert set(files_list).issuperset(expected_files + CONTENT_FILES), assert_msg
 
 


### PR DESCRIPTION
Fix for #241

These files are expected inside the backup folder:
```
ONLINE:
With pulp: ['candlepin.dump', 'config_files.tar.gz', '.config.snar', 'foreman.dump', 'metadata.yml', 'pg_globals.dump', 'pulpcore.dump', 'pulp_data.tar', '.pulp.snar']
Skip pulp: ['candlepin.dump', 'config_files.tar.gz', '.config.snar', 'foreman.dump', 'metadata.yml', 'pg_globals.dump', 'pulpcore.dump']

OFFLINE:
With pulp: ['config_files.tar.gz', '.config.snar', 'metadata.yml', 'pgsql_data.tar.gz', '.postgres.snar', 'pulp_data.tar', '.pulp.snar']
Skip pulp: ['config_files.tar.gz', '.config.snar', 'metadata.yml', 'pgsql_data.tar.gz', '.postgres.snar']
```

Test results against Satellite 6.10.0 snap 20:
```
(venv) [vsedmik@localhost testfm]$ pytest -s --ansible-host-pattern server --ansible-user=root --ansible-inventory testfm/inventory tests/test_backup.py::test_positive_backup_online tests/test_backup.py::test_positive_backup_online_skip_pulp_content tests/test_backup.py::test_positive_backup_offline tests/test_backup.py::test_positive_backup_offline_skip_pulp_content
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.9.7, pytest-3.6.1, py-1.10.0, pluggy-0.6.0
ansible: 2.9.20
rootdir: /home/vsedmik/PycharmProjects/testfm, inifile:
plugins: ansible-2.2.3
collected 4 items                                                                                                                                                                                                                         
...
======================================================================================================= 4 passed in 670.91 seconds ========================================================================================================
```