### PR TITLE
Fix tests related to repositories setup

### DIFF
--- a/testfm/constants.py
+++ b/testfm/constants.py
@@ -58,6 +58,10 @@ sat_610_repos = [
     "rhel-7-server-ansible-2.9-rpms",
     "rhel-7-server-satellite-6.10-rpms",
 ] + common_repos
+sat_70_repos = [
+    "rhel-7-server-ansible-2.9-rpms",
+    "rhel-7-server-satellite-7.0-rpms",
+] + common_repos
 sat_beta_repo = [
     "rhel-server-7-satellite-6-beta-rpms",
     "rhel-7-server-ansible-2.9-rpms",
@@ -80,6 +84,11 @@ cap_610_repos = [
     "rhel-7-server-satellite-tools-6.10-rpms",
     "rhel-7-server-satellite-capsule-6.10-rpms",
 ] + common_repos
+cap_70_repos = [
+    "rhel-7-server-ansible-2.9-rpms",
+    "rhel-7-server-satellite-tools-7.0-rpms",
+    "rhel-7-server-satellite-capsule-7.0-rpms",
+] + common_repos
 cap_beta_repo = [
     "rhel-server-7-satellite-capsule-6-beta-rpms",
     "rhel-7-server-ansible-2.9-rpms",
@@ -96,11 +105,13 @@ sat_repos = {
     "6.8": sat_68_repos,
     "6.9": sat_69_repos,
     "6.10": sat_610_repos,
+    "7.0": sat_70_repos,
 }
 cap_repos = {
     "6.8": cap_68_repos,
     "6.9": cap_69_repos,
     "6.10": cap_610_repos,
+    "7.0": cap_70_repos,
 }
 foreman_maintain_yml = "/etc/foreman-maintain/foreman_maintain.yml"
 epel_repo = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -382,7 +382,7 @@ def test_positive_satellite_repositories_setup(setup_subscribe_to_cdn_dogfood, a
 
     :CaseImportance: Critical
     """
-    for ver in ["6.7", "6.8", "6.9"]:
+    for ver in ["6.7", "6.8", "6.9", "6.10"]:
         contacted = ansible_module.command(Advanced.run_repositories_setup({"version": ver}))
         for result in contacted.values():
             logger.info(result["stdout"])
@@ -397,7 +397,7 @@ def test_positive_satellite_repositories_setup(setup_subscribe_to_cdn_dogfood, a
     # Verify that all required beta repositories gets enabled
     export_command = "export FOREMAN_MAINTAIN_USE_BETA=1;"
     contacted = ansible_module.shell(
-        export_command + Advanced.run_repositories_setup({"version": "6.9"})
+        export_command + Advanced.run_repositories_setup({"version": "6.10"})
     )
     for result in contacted.values():
         logger.info(result["stdout"])
@@ -409,13 +409,13 @@ def test_positive_satellite_repositories_setup(setup_subscribe_to_cdn_dogfood, a
         for repo in sat_beta_repo:
             assert repo in result["stdout"]
 
-    # 6.10 till not GA
-    contacted = ansible_module.shell(Advanced.run_repositories_setup({"version": "6.10"}))
+    # 7.0 till not GA
+    contacted = ansible_module.shell(Advanced.run_repositories_setup({"version": "7.0"}))
     for result in contacted.values():
         logger.info(result["stdout"])
         assert "FAIL" in result["stdout"]
         assert result["rc"] == 1
-        for repo in sat_repos["6.10"]:
+        for repo in sat_repos["7.0"]:
             assert repo in result["stdout"]
 
 
@@ -438,7 +438,7 @@ def test_positive_capsule_repositories_setup(setup_subscribe_to_cdn_dogfood, ans
 
     :CaseImportance: Critical
     """
-    for ver in ["6.8", "6.9"]:
+    for ver in ["6.8", "6.9", "6.10"]:
         contacted = ansible_module.command(Advanced.run_repositories_setup({"version": ver}))
         for result in contacted.values():
             logger.info(result["stdout"])
@@ -452,7 +452,7 @@ def test_positive_capsule_repositories_setup(setup_subscribe_to_cdn_dogfood, ans
     # Verify that all required beta repositories gets enabled
     export_command = "export FOREMAN_MAINTAIN_USE_BETA=1;"
     contacted = ansible_module.shell(
-        export_command + Advanced.run_repositories_setup({"version": "6.9"})
+        export_command + Advanced.run_repositories_setup({"version": "6.10"})
     )
     for result in contacted.values():
         logger.info(result["stdout"])
@@ -464,11 +464,11 @@ def test_positive_capsule_repositories_setup(setup_subscribe_to_cdn_dogfood, ans
         for repo in cap_beta_repo:
             assert repo in result["stdout"]
 
-    # 6.10 till not GA
-    contacted = ansible_module.shell(Advanced.run_repositories_setup({"version": "6.10"}))
+    # 7.0 till not GA
+    contacted = ansible_module.shell(Advanced.run_repositories_setup({"version": "7.0"}))
     for result in contacted.values():
         logger.info(result["stdout"])
         assert "FAIL" in result["stdout"]
         assert result["rc"] == 1
-        for repo in cap_repos["6.10"]:
+        for repo in cap_repos["7.0"]:
             assert repo in result["stdout"]


### PR DESCRIPTION
**Test Results:**

**Satellite:**
```
$ pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory tests/test_advanced.py -k test_positive_satellite_repositories_setup
============================================== test session starts ========================================================
platform linux -- Python 3.8.8, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/sganar/foreman/fm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/sganar/foreman/testfm, inifile:
plugins: ansible-2.2.3
collected 14 items / 13 deselected                                                                                                                                                                                                        

tests/test_advanced.py::test_positive_satellite_repositories_setup PASSED                                                                                                                                                           [100%]

====================================== 1 passed, 13 deselected in 1815.01 seconds ================================================
```
**Capsule:**
```
$ pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory tests/test_advanced.py -k test_positive_capsule_repositories_setup
========================================== test session starts ================================================
platform linux -- Python 3.8.8, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/sganar/foreman/fm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/sganar/foreman/testfm, inifile:
plugins: ansible-2.2.3
collected 14 items / 13 deselected                                                                                                                                                                                                        

tests/test_advanced.py::test_positive_capsule_repositories_setup PASSED                                                                                                                                                             [100%]

===================================== 1 passed, 13 deselected in 761.08 seconds ===================================================
```