### PR TITLE
Add test for BZ-1945916

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -618,3 +618,21 @@ def setup_packages_update(request, ansible_module):
             assert result["rc"] == 0
 
     request.addfinalizer(teardown_packages_update)
+
+
+@pytest.fixture(scope="function")
+def setup_rpmsave_file(request, ansible_module):
+    """This fixture is used to create a .rpmsave file"""
+    file_name = gen_string("alpha")
+    setup = ansible_module.file(path=f"/etc/foreman/dynflow/{file_name}.yml.rpmsave", state="touch")
+    for result in setup.values():
+        assert result["changed"] is True
+
+    def teardown_rpmsave_file():
+        contacted = ansible_module.file(
+            path=f"/etc/foreman/dynflow/{file_name}.yml.rpmsave", state="absent"
+        )
+        for result in contacted.values():
+            assert result["changed"] is True
+
+    request.addfinalizer(teardown_rpmsave_file)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -288,3 +288,33 @@ def test_positive_foreman_maintain_service_list_sidekiq(ansible_module):
         assert "dynflow-sidekiq@orchestrator" in result["stdout"]
         assert "dynflow-sidekiq@worker" in result["stdout"]
         assert "dynflow-sidekiq@worker-hosts-queue" in result["stdout"]
+
+
+def test_positive_service_status_rpmsave(ansible_module, setup_rpmsave_file):
+    """Verify foreman-maintain service status doesn't pick up any backup files like .rpmsave,
+    or any file with .yml which don't exist as services.
+
+    :id: dda696c9-7385-4450-8380-b694e4016661
+
+    :setup:
+        1. foreman-maintain should be installed.
+
+    :steps:
+        1. Run foreman-maintain service status.
+        2. Verify foreman-maintain service status doesn't pick up any backup files like
+           .rpmsave, or any file with .yml which don't exist as services.
+
+
+    :expectedresults: foreman-maintain service status shouldn't pick
+                      invalid services with extension .rpmsave
+
+    :BZ: 1945916, 1962853
+
+    :CaseImportance: High
+    """
+    contacted = ansible_module.command(Service.service_status(["-b"]))
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "rpmsave" not in result["stdout"]
+        assert "FAIL" not in result["stdout"]
+        assert result["rc"] == 0


### PR DESCRIPTION
**Test Results:**

```
$ pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory tests/test_service.py -k test_positive_foreman_maintain_service_status_bz1945916
============================================ test session starts =========================================================
platform linux -- Python 3.8.8, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/sganar/foreman/fm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/sganar/foreman/testfm, inifile:
plugins: ansible-2.2.3
collected 11 items / 10 deselected                                                                                                                                                                                                        

tests/test_service.py::test_positive_foreman_maintain_service_status_bz1945916 PASSED                                                                                                                                               [100%]

===================================== 1 passed, 10 deselected in 36.86 seconds ===================================================
```