### PR TITLE
Test fix related to hammer setup

### DIFF
--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -74,7 +74,7 @@ def test_positive_foreman_maintain_hammer_setup(change_admin_passwd, ansible_mod
     # Verify wrong_password isn't updated in fm_hammer_yml
     output = ansible_module.command(f"grep -i ':password: wrong_password' {fm_hammer_yml}")
     for result in output.values():
-        assert result["rc"] == 1
+        assert result["rc"] != 0
         assert "wrong_password" not in result["stdout"]
 
     # try with correct password


### PR DESCRIPTION
**Test Results:**

```
$ pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory tests/test_advanced.py -k test_positive_foreman_maintain_hammer_setup
===============================================test session starts =====================================================
platform linux -- Python 3.8.6, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/sganar/foreman/fm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/sganar/foreman/testfm, inifile:
plugins: ansible-2.2.3
collected 14 items / 13 deselected                                                                                                                                                                                

tests/test_advanced.py::test_positive_foreman_maintain_hammer_setup PASSED                                                                                                                                  [100%]

====================================== 1 passed, 13 deselected in 167.14 seconds =======================================================
```