### PR TITLE
Test fix for corrupted-roles check

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -500,7 +500,9 @@ def setup_corrupted_role(request, ansible_module):
     role_name = "test_role"
     resource_type = gen_string("alpha")
     ansible_module.command(f"hammer role create --name {role_name}")
-    ansible_module.command(f"hammer filter create --role {role_name} --permission-ids 62,68")
+    ansible_module.command(
+        f"hammer filter create --role {role_name} --permissions view_hosts,console_hosts"
+    )
     permission_name = r"'\''console_hosts'\''"
     resource_type = rf"'\''{resource_type}'\''"
     setup = ansible_module.shell(


### PR DESCRIPTION
**Test Results:**

```
$ pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory tests/test_health.py -k test_positive_corrupted_roles
=========================================== test session starts ================================================================
platform linux -- Python 3.8.6, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/sganar/foreman/fm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/sganar/foreman/testfm, inifile:
plugins: ansible-2.2.3
collected 29 items / 28 deselected                                                                                                                                                                                

tests/test_health.py::test_positive_corrupted_roles PASSED                                                                                                                                                  [100%]

====================================== 1 passed, 28 deselected in 76.72 seconds ===================================================
```