### PR TITLE
Test fix related to epel repository check

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -313,7 +313,7 @@ def setup_subscribe_to_cdn_dogfood(request, ansible_module):
 def setup_epel_repository(request, ansible_module):
     """Setup/teardown fixture used by test_positive_check_epel_repository
     and test_positive_check_epel_repository_with_invalid_repo"""
-    setup = ansible_module.yum(name=epel_repo, state="present")
+    setup = ansible_module.yum(name=epel_repo, state="present", disable_gpg_check="yes")
     assert setup.values()[0]["rc"] == 0
 
     def teardown_epel_repository():


### PR DESCRIPTION
**Test Results:**
```
Sat 7.0 Rhel7:
$ pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory tests/test_health.py -k test_positive_check_epel_repository
============================================= test session starts ===================================================================
platform linux -- Python 3.8.6, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/sganar/foreman/fm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/sganar/foreman/testfm, inifile:
plugins: ansible-2.2.3
collected 29 items / 27 deselected                                                                                                                                                                                                                                                       

tests/test_health.py::test_positive_check_epel_repository PASSED                                                                                                                                                                                                                   [ 50%]
tests/test_health.py::test_positive_check_epel_repository_with_invalid_repo SKIPPED                                                                                                                                                                                                [100%]

==================================== 1 passed, 1 skipped, 27 deselected in 108.01 seconds =================================================
```
```
Sat 7.0 Rhel8:
$ pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory tests/test_health.py -k test_positive_check_epel_repository
========================================== test session starts ================================================================
platform linux -- Python 3.8.6, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/sganar/foreman/fm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/sganar/foreman/testfm, inifile:
plugins: ansible-2.2.3
collected 29 items / 27 deselected                                                                                                                                                                                                                                                       

tests/test_health.py::test_positive_check_epel_repository PASSED                                                                                                                                                                                                                   [ 50%]
tests/test_health.py::test_positive_check_epel_repository_with_invalid_repo SKIPPED                                                                                                                                                                                                [100%]

================================ 1 passed, 1 skipped, 27 deselected in 114.90 seconds ================================================================
```