### PR TITLE
foreman maintain to satellite maintain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ There are a few other things you need to do before continuing:
 
 - Make sure ssh-key is copied to the test system.
 
-- Make sure foreman maintain is installed on foreman/satellite server.
+- Make sure satellite maintain is installed on foreman/satellite server.
 
 Running the Tests
 -----------------

--- a/docs/source/api/conf.py
+++ b/docs/source/api/conf.py
@@ -57,7 +57,7 @@ texinfo_documents = [
         "TestFM Documentation",
         author,
         "TestFM",
-        "A test suite based on pytest-ansible that exercises The Foreman-maintain tool.",
+        "A test suite based on pytest-ansible that exercises The Satellite-maintain tool.",
         "Miscellaneous",
     ),
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,7 @@ texinfo_documents = [
         "Testfm Documentation",
         author,
         "Testfm",
-        "A test suite based on pytest-ansible that exercises The Foreman-maintain tool.",
+        "A test suite based on pytest-ansible that exercises The Satellite-maintain tool.",
         "Miscellaneous",
     ),
 ]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ REQUIREMENTS = [
 setup(
     name="testfm",
     version=VERSION,
-    description="TestFM is a test suite which exercises foreman-maintain tool.",
+    description="TestFM is a test suite which exercises satellite-maintain tool.",
     long_description=LONG_DESCRIPTION,
     url="https://github.com/SatelliteQE/testfm",
     author="Nikhil Kathole",

--- a/testfm/advanced.py
+++ b/testfm/advanced.py
@@ -32,7 +32,7 @@ from testfm.base import Base
 
 
 class Advanced(Base):
-    """Manipulates Foreman-maintain's advanced procedure run command"""
+    """Manipulates Satellite-maintain's advanced procedure run command"""
 
     command_base = "advanced procedure run"
 

--- a/testfm/advanced.py
+++ b/testfm/advanced.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    foreman-maintain advanced procedure run [OPTIONS] SUBCOMMAND [ARG] ...
+    satellite-maintain advanced procedure run [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters:
     SUBCOMMAND                    subcommand
@@ -38,7 +38,7 @@ class Advanced(Base):
 
     @classmethod
     def run_service_restart(cls, options=None):
-        """Build foreman-maintain advanced procedure run service-restart"""
+        """Build satellite-maintain advanced procedure run service-restart"""
 
         cls.command_sub = "service-restart"
 
@@ -51,7 +51,7 @@ class Advanced(Base):
 
     @classmethod
     def run_katello_service_stop(cls, options=None):
-        """Build foreman-maintain advanced procedure run service-stop"""
+        """Build satellite-maintain advanced procedure run service-stop"""
 
         cls.command_sub = "service-stop"
 
@@ -64,7 +64,7 @@ class Advanced(Base):
 
     @classmethod
     def run_service_start(cls, options=None):
-        """Build foreman-maintain advanced procedure run service-start"""
+        """Build satellite-maintain advanced procedure run service-start"""
 
         cls.command_sub = "service-start"
 
@@ -77,7 +77,7 @@ class Advanced(Base):
 
     @classmethod
     def run_packages_update(cls, options=None):
-        """Build foreman-maintain advanced procedure run packages-update"""
+        """Build satellite-maintain advanced procedure run packages-update"""
 
         cls.command_sub = "packages-update"
 
@@ -90,7 +90,7 @@ class Advanced(Base):
 
     @classmethod
     def run_disable_maintenance_mode(cls, options=None):
-        """Build foreman-maintain advanced procedure run maintenance-mode-disable"""
+        """Build satellite-maintain advanced procedure run maintenance-mode-disable"""
 
         cls.command_sub = "maintenance-mode-disable"
 
@@ -103,7 +103,7 @@ class Advanced(Base):
 
     @classmethod
     def run_enable_maintenance_mode(cls, options=None):
-        """Build foreman-maintain advanced procedure run maintenance-mode-enable"""
+        """Build satellite-maintain advanced procedure run maintenance-mode-enable"""
 
         cls.command_sub = "maintenance-mode-enable"
 
@@ -116,7 +116,7 @@ class Advanced(Base):
 
     @classmethod
     def run_foreman_tasks_delete(cls, options=None):
-        """Build foreman-maintain advanced procedure run foreman-tasks-delete"""
+        """Build satellite-maintain advanced procedure run foreman-tasks-delete"""
 
         cls.command_sub = "foreman-tasks-delete"
 
@@ -129,7 +129,7 @@ class Advanced(Base):
 
     @classmethod
     def run_foreman_tasks_resume(cls, options=None):
-        """Build foreman-maintain advanced procedure run foreman-tasks-resume"""
+        """Build satellite-maintain advanced procedure run foreman-tasks-resume"""
 
         cls.command_sub = "foreman-tasks-resume"
 
@@ -142,7 +142,7 @@ class Advanced(Base):
 
     @classmethod
     def run_sync_plans_enable(cls, options=None):
-        """Build foreman-maintain advanced procedure run sync-plans-enable"""
+        """Build satellite-maintain advanced procedure run sync-plans-enable"""
 
         cls.command_sub = "sync-plans-enable"
 
@@ -155,7 +155,7 @@ class Advanced(Base):
 
     @classmethod
     def run_sync_plans_disable(cls, options=None):
-        """Build foreman-maintain advanced procedure run sync-plans-disable"""
+        """Build satellite-maintain advanced procedure run sync-plans-disable"""
 
         cls.command_sub = "sync-plans-disable"
 
@@ -168,7 +168,7 @@ class Advanced(Base):
 
     @classmethod
     def run_foreman_tasks_ui_investigate(cls, options=None):
-        """Build foreman-maintain advanced procedure run foreman-tasks-ui-investigate"""
+        """Build satellite-maintain advanced procedure run foreman-tasks-ui-investigate"""
 
         cls.command_sub = "foreman-tasks-ui-investigate"
 
@@ -181,7 +181,7 @@ class Advanced(Base):
 
     @classmethod
     def run_hammer_setup(cls, options=None):
-        """Build foreman-maintain advanced procedure run hammer-setup"""
+        """Build satellite-maintain advanced procedure run hammer-setup"""
 
         cls.command_sub = "hammer-setup"
 
@@ -194,7 +194,7 @@ class Advanced(Base):
 
     @classmethod
     def run_repositories_setup(cls, options=None):
-        """Build foreman-maintain advanced procedure run repositories-setup"""
+        """Build satellite-maintain advanced procedure run repositories-setup"""
 
         cls.command_sub = "repositories-setup"
 

--- a/testfm/advanced_by_tag.py
+++ b/testfm/advanced_by_tag.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    foreman-maintain advanced procedure by-tag [OPTIONS] SUBCOMMAND [ARG] ...
+    satellite-maintain advanced procedure by-tag [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters:
     SUBCOMMAND                    subcommand
@@ -21,13 +21,13 @@ from testfm.base import Base
 
 
 class AdvancedByTag(Base):
-    """Manipulates Foreman-maintain's advanced procedure by-tag command"""
+    """Manipulates Satellite-maintain's advanced procedure by-tag command"""
 
     command_base = "advanced procedure by-tag"
 
     @classmethod
     def post_migrations(cls, options=None):
-        """Build foreman-maintain advanced procedure by-tag post-migrations"""
+        """Build satellite-maintain advanced procedure by-tag post-migrations"""
 
         cls.command_sub = "post-migrations"
 
@@ -40,7 +40,7 @@ class AdvancedByTag(Base):
 
     @classmethod
     def pre_migrations(cls, options=None):
-        """Build foreman-maintain advanced procedure by-tag pre-migrations"""
+        """Build satellite-maintain advanced procedure by-tag pre-migrations"""
 
         cls.command_sub = "pre-migrations"
 
@@ -53,7 +53,7 @@ class AdvancedByTag(Base):
 
     @classmethod
     def restore(cls, options=None):
-        """Build foreman-maintain advanced procedure by-tag backup"""
+        """Build satellite-maintain advanced procedure by-tag backup"""
 
         cls.command_sub = "restore"
 

--- a/testfm/backup.py
+++ b/testfm/backup.py
@@ -20,7 +20,7 @@ from testfm.base import Base
 
 
 class Backup(Base):
-    """Manipulates Foreman-maintain's backup command"""
+    """Manipulates Satellite-maintain's backup command"""
 
     command_base = "backup"
 

--- a/testfm/backup.py
+++ b/testfm/backup.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    foreman-maintain backup [OPTIONS] SUBCOMMAND [ARG] ...
+    satellite-maintain backup [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters:
     SUBCOMMAND                    subcommand
@@ -26,7 +26,7 @@ class Backup(Base):
 
     @classmethod
     def run_online_backup(cls, options=None):
-        """Build foreman-maintain backup online"""
+        """Build satellite-maintain backup online"""
 
         cls.command_sub = "online"
 
@@ -38,7 +38,7 @@ class Backup(Base):
 
     @classmethod
     def run_offline_backup(cls, options=None):
-        """Build foreman-maintain backup offline"""
+        """Build satellite-maintain backup offline"""
 
         cls.command_sub = "offline"
 
@@ -50,7 +50,7 @@ class Backup(Base):
 
     @classmethod
     def run_snapshot_backup(cls, options=None):
-        """Build foreman-maintain backup snapshot"""
+        """Build satellite-maintain backup snapshot"""
 
         cls.command_sub = "snapshot"
 

--- a/testfm/base.py
+++ b/testfm/base.py
@@ -1,10 +1,10 @@
 class Base:
     """
-    @param command_base: base command of foreman-maintain.
-    Output of recent `foreman-maintain --help`::
+    @param command_base: base command of satellite-maintain.
+    Output of recent `satellite-maintain --help`::
 
         Usage:
-            foreman-maintain [OPTIONS] SUBCOMMAND [ARG] ...
+            satellite-maintain [OPTIONS] SUBCOMMAND [ARG] ...
 
         Parameters:
             SUBCOMMAND                    subcommand
@@ -30,7 +30,7 @@ class Base:
 
     @classmethod
     def _construct_command(cls, options=None):
-        """Build a foreman-maintain command based on the options passed"""
+        """Build a satellite-maintain command based on the options passed"""
         tail = ""
         if isinstance(options, list):
             for val in options:
@@ -49,5 +49,5 @@ class Base:
                         val = ",".join(str(el) for el in val)
                     tail += f' --{key}="{val}"'
 
-        cmd = f"foreman-maintain {cls.command_base} {cls.command_sub} {tail.strip()}"
+        cmd = f"satellite-maintain {cls.command_base} {cls.command_sub} {tail.strip()}"
         return cmd

--- a/testfm/constants.py
+++ b/testfm/constants.py
@@ -122,7 +122,7 @@ cap_repos = {
     "6.10": cap_610_repos,
     "7.0": cap_70_repos,
 }
-foreman_maintain_yml = "/etc/foreman-maintain/foreman_maintain.yml"
+satellite_maintain_yml = "/etc/foreman-maintain/foreman_maintain.yml"
 epel_repo = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 satellite_answer_file = "/etc/foreman-installer/scenarios.d/satellite-answers.yaml"
 fm_hammer_yml = "/etc/foreman-maintain/foreman-maintain-hammer.yml"

--- a/testfm/content.py
+++ b/testfm/content.py
@@ -20,7 +20,7 @@ from testfm.base import Base
 
 
 class Content(Base):
-    """Manipulates Foreman-maintain's content command"""
+    """Manipulates Satellite-maintain's content command"""
 
     command_base = "content"
 

--- a/testfm/content.py
+++ b/testfm/content.py
@@ -26,7 +26,7 @@ class Content(Base):
 
     @classmethod
     def prepare(cls, options=None):
-        """Build foreman-maintain content prepare"""
+        """Build satellite-maintain content prepare"""
 
         cls.command_sub = "prepare"
 
@@ -39,7 +39,7 @@ class Content(Base):
 
     @classmethod
     def prepare_abort(cls, options=None):
-        """Build foreman-maintain content prepare-abort"""
+        """Build satellite-maintain content prepare-abort"""
 
         cls.command_sub = "prepare-abort"
 
@@ -52,7 +52,7 @@ class Content(Base):
 
     @classmethod
     def migration_stats(cls, options=None):
-        """Build foreman-maintain content migration-stats"""
+        """Build satellite-maintain content migration-stats"""
 
         cls.command_sub = "migration-stats"
 
@@ -65,7 +65,7 @@ class Content(Base):
 
     @classmethod
     def migration_reset(cls, options=None):
-        """Build foreman-maintain content migration-reset"""
+        """Build satellite-maintain content migration-reset"""
 
         cls.command_sub = "migration-reset"
 
@@ -78,7 +78,7 @@ class Content(Base):
 
     @classmethod
     def remove_pulp2(cls, options=None):
-        """Build foreman-maintain content remove-pulp2"""
+        """Build satellite-maintain content remove-pulp2"""
 
         cls.command_sub = "remove-pulp2"
 

--- a/testfm/factory.py
+++ b/testfm/factory.py
@@ -6,7 +6,7 @@ from testfm.upgrade import Upgrade
 def check_health():
     """
     Usage:
-    foreman-maintain health check [OPTIONS]
+    satellite-maintain health check [OPTIONS]
 
     Options:
         --label label                 Limit only for a specific label.
@@ -30,7 +30,7 @@ def check_health():
 def list_versions():
     """
     Usage:
-    foreman-maintain upgrade list-versions [OPTIONS]
+    satellite-maintain upgrade list-versions [OPTIONS]
 
     Options:
         -h, --help                    print help
@@ -42,7 +42,7 @@ def list_versions():
 def advanced_procedure_run_service_restart():
     """
     Usage:
-    foreman-maintain advanced procedure run katello-service-restart [OPTIONS]
+    satellite-maintain advanced procedure run katello-service-restart [OPTIONS]
 
     Options:
         --only ONLY                   A comma-separated list of services to

--- a/testfm/health.py
+++ b/testfm/health.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    foreman-maintain health [OPTIONS] SUBCOMMAND [ARG] ...
+    satellite-maintain health [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters:
     SUBCOMMAND                    subcommand
@@ -18,15 +18,15 @@ from testfm.base import Base
 
 
 class Health(Base):
-    """Manipulates Foreman-maintain's health command"""
+    """Manipulates Satellite-maintain's health command"""
 
     command_base = "health"
 
     @classmethod
     def check(cls, options=None):
-        """Build foreman-maintain health check
+        """Build satellite-maintain health check
         Usage:
-            foreman-maintain health check [OPTIONS]
+            satellite-maintain health check [OPTIONS]
 
         Options:
             --label label                 Limit only for a specific label.
@@ -54,7 +54,7 @@ class Health(Base):
 
     @classmethod
     def list(cls, options=None):
-        """Build foreman-maintain health list"""
+        """Build satellite-maintain health list"""
         cls.command_sub = "list"
 
         if options is None:
@@ -66,7 +66,7 @@ class Health(Base):
 
     @classmethod
     def list_tags(cls, options=None):
-        """Build foreman-maintain health list-tags"""
+        """Build satellite-maintain health list-tags"""
         cls.command_sub = "list-tags"
 
         if options is None:

--- a/testfm/maintenance_mode.py
+++ b/testfm/maintenance_mode.py
@@ -19,7 +19,7 @@ from testfm.base import Base
 
 
 class MaintenanceMode(Base):
-    """Manipulates Foreman-maintain's maintenance-mode command"""
+    """Manipulates Satellite-maintain's maintenance-mode command"""
 
     command_base = "maintenance-mode"
 

--- a/testfm/maintenance_mode.py
+++ b/testfm/maintenance_mode.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    foreman-maintain maintenance-mode [OPTIONS] SUBCOMMAND [ARG] ...
+    satellite-maintain maintenance-mode [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters:
     SUBCOMMAND                    subcommand
@@ -25,7 +25,7 @@ class MaintenanceMode(Base):
 
     @classmethod
     def start(cls, options=None):
-        """foreman-maintain maintenance-mode start [OPTIONS]"""
+        """satellite-maintain maintenance-mode start [OPTIONS]"""
         cls.command_sub = "start"
 
         if options is None:
@@ -37,7 +37,7 @@ class MaintenanceMode(Base):
 
     @classmethod
     def stop(cls, options=None):
-        """foreman-maintain maintenance-mode stop [OPTIONS]"""
+        """satellite-maintain maintenance-mode stop [OPTIONS]"""
         cls.command_sub = "stop"
 
         if options is None:
@@ -49,7 +49,7 @@ class MaintenanceMode(Base):
 
     @classmethod
     def status(cls, options=None):
-        """foreman-maintain maintenance-mode status [OPTIONS]"""
+        """satellite-maintain maintenance-mode status [OPTIONS]"""
         cls.command_sub = "status"
 
         if options is None:
@@ -61,7 +61,7 @@ class MaintenanceMode(Base):
 
     @classmethod
     def is_enabled(cls, options=None):
-        """foreman-maintain maintenance-mode is-enabled [OPTIONS]"""
+        """satellite-maintain maintenance-mode is-enabled [OPTIONS]"""
         cls.command_sub = "is-enabled"
 
         if options is None:

--- a/testfm/packages.py
+++ b/testfm/packages.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    foreman-maintain packages [OPTIONS] SUBCOMMAND [ARG] ...
+    satellite-maintain packages [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters:
     SUBCOMMAND                    subcommand
@@ -22,7 +22,7 @@ from testfm.base import Base
 
 
 class Packages(Base):
-    """Manipulates Foreman-maintain's packages command"""
+    """Manipulates Satellite-maintain's packages command"""
 
     command_base = "packages"
 
@@ -30,7 +30,7 @@ class Packages(Base):
     def lock(cls, options=None):
         """
         Usage:
-            foreman-maintain packages lock [OPTIONS]
+            satellite-maintain packages lock [OPTIONS]
 
         Options:
             -y, --assumeyes               Automatically answer yes for all questions
@@ -54,7 +54,7 @@ class Packages(Base):
     def unlock(cls, options=None):
         """
         Usage:
-            foreman-maintain packages unlock [OPTIONS]
+            satellite-maintain packages unlock [OPTIONS]
 
         Options:
             -y, --assumeyes               Automatically answer yes for all questions
@@ -78,7 +78,7 @@ class Packages(Base):
     def status(cls, options=None):
         """
         Usage:
-            foreman-maintain packages status [OPTIONS]
+            satellite-maintain packages status [OPTIONS]
 
         Options:
             -y, --assumeyes               Automatically answer yes for all questions
@@ -102,7 +102,7 @@ class Packages(Base):
     def install(cls, options=None):
         """
         Usage:
-            foreman-maintain packages install [OPTIONS] PACKAGES ...
+            satellite-maintain packages install [OPTIONS] PACKAGES ...
 
         Options:
             -y, --assumeyes               Automatically answer yes for all questions
@@ -126,7 +126,7 @@ class Packages(Base):
     def update(cls, options=None):
         """
         Usage:
-            foreman-maintain packages update [OPTIONS] PACKAGES ...
+            satellite-maintain packages update [OPTIONS] PACKAGES ...
 
         Options:
             -y, --assumeyes               Automatically answer yes for all questions
@@ -150,7 +150,7 @@ class Packages(Base):
     def is_locked(cls, options=None):
         """
         Usage:
-            foreman-maintain packages is-locked [OPTIONS]
+            satellite-maintain packages is-locked [OPTIONS]
 
         Options:
             -y, --assumeyes               Automatically answer yes for all questions
@@ -174,7 +174,7 @@ class Packages(Base):
     def check_update(cls, options=None):
         """
         Usage:
-            foreman-maintain packages check-update [OPTIONS]
+            satellite-maintain packages check-update [OPTIONS]
 
         Options:
             -y, --assumeyes               Automatically answer yes for all questions

--- a/testfm/restore.py
+++ b/testfm/restore.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    foreman-maintain restore [OPTIONS] BACKUP_DIR
+    satellite-maintain restore [OPTIONS] BACKUP_DIR
 
 Parameters:
     BACKUP_DIR                    Path to backup directory to restore
@@ -18,6 +18,6 @@ from testfm.base import Base
 
 
 class Restore(Base):
-    """Manipulates Foreman-maintain's restore command"""
+    """Manipulates Satellite-maintain's restore command"""
 
     command_base = "restore"

--- a/testfm/service.py
+++ b/testfm/service.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    foreman-maintain service [OPTIONS] SUBCOMMAND [ARG] ...
+    satellite-maintain service [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters:
     SUBCOMMAND                    subcommand
@@ -22,13 +22,13 @@ from testfm.base import Base
 
 
 class Service(Base):
-    """Manipulates Foreman-maintain's service command"""
+    """Manipulates Satellite-maintain's service command"""
 
     command_base = "service"
 
     @classmethod
     def service_start(cls, options=None):
-        """Build foreman-maintain service start"""
+        """Build satellite-maintain service start"""
 
         cls.command_sub = "start"
 
@@ -41,7 +41,7 @@ class Service(Base):
 
     @classmethod
     def service_stop(cls, options=None):
-        """Build foreman-maintain service stop"""
+        """Build satellite-maintain service stop"""
 
         cls.command_sub = "stop"
 
@@ -54,7 +54,7 @@ class Service(Base):
 
     @classmethod
     def service_restart(cls, options=None):
-        """Build foreman-maintain service"""
+        """Build satellite-maintain service"""
 
         cls.command_sub = "restart"
 
@@ -67,7 +67,7 @@ class Service(Base):
 
     @classmethod
     def service_status(cls, options=None):
-        """Build foreman-maintain service status"""
+        """Build satellite-maintain service status"""
 
         cls.command_sub = "status"
 
@@ -80,7 +80,7 @@ class Service(Base):
 
     @classmethod
     def service_enable(cls, options=None):
-        """Build foreman-maintain service enable"""
+        """Build satellite-maintain service enable"""
 
         cls.command_sub = "enable"
 
@@ -93,7 +93,7 @@ class Service(Base):
 
     @classmethod
     def service_disable(cls, options=None):
-        """Build foreman-maintain service disable"""
+        """Build satellite-maintain service disable"""
 
         cls.command_sub = "disable"
 
@@ -106,7 +106,7 @@ class Service(Base):
 
     @classmethod
     def service_list(cls, options=None):
-        """Build foreman-maintain service list"""
+        """Build satellite-maintain service list"""
 
         cls.command_sub = "list"
 

--- a/testfm/upgrade.py
+++ b/testfm/upgrade.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    foreman-maintain upgrade [OPTIONS] SUBCOMMAND [ARG] ...
+    satellite-maintain upgrade [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters:
     SUBCOMMAND                    subcommand
@@ -19,13 +19,13 @@ from testfm.base import Base
 
 
 class Upgrade(Base):
-    """Manipulates Foreman-maintain's health command"""
+    """Manipulates Satellite-maintain's health command"""
 
     command_base = "upgrade"
 
     @classmethod
     def list_versions(cls, options=None):
-        """Build foreman-maintain upgrade list-versions"""
+        """Build satellite-maintain upgrade list-versions"""
         cls.command_sub = "list-versions"
 
         if options is None:
@@ -37,7 +37,7 @@ class Upgrade(Base):
 
     @classmethod
     def check(cls, options=None):
-        """Build foreman-maintain upgrade check"""
+        """Build satellite-maintain upgrade check"""
         cls.command_sub = "check"
 
         if options is None:
@@ -49,7 +49,7 @@ class Upgrade(Base):
 
     @classmethod
     def run(cls, options=None):
-        """Build foreman-maintain upgrade run"""
+        """Build satellite-maintain upgrade run"""
         cls.command_sub = "run"
 
         if options is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,13 +12,13 @@ from testfm.constants import epel_repo
 from testfm.constants import FAKE_YUM0_REPO
 from testfm.constants import fm_hammer_yml
 from testfm.constants import FM_RHN_POOLID
-from testfm.constants import foreman_maintain_yml
 from testfm.constants import gems_path
 from testfm.constants import HOTFIX_URL
 from testfm.constants import katello_ca_consumer
 from testfm.constants import RHN_PASSWORD
 from testfm.constants import RHN_USERNAME
 from testfm.constants import satellite_answer_file
+from testfm.constants import satellite_maintain_yml
 from testfm.constants import upstream_url
 from testfm.helpers import product
 from testfm.helpers import server
@@ -138,7 +138,7 @@ def setup_katello_service_stop(request, ansible_module):
 @pytest.fixture(scope="function")
 def setup_install_pexpect(ansible_module, request):
     """This fixture is used to install pexpect on host.
-    It is used by test test_positive_foreman_maintain_hammer_setup,
+    It is used by test test_positive_satellite_maintain_hammer_setup,
     test_positive_foreman_tasks_ui_investigate,
     test_positive_check_old_foreman_tasks of test_advanced.py and in
     fixture setup_puppet_empty_cert.
@@ -161,7 +161,7 @@ def setup_sync_plan(request, ansible_module):
     """
     sync_plan_name = gen_string("alpha")
     ansible_module.lineinfile(
-        dest=foreman_maintain_yml, insertafter="EOF", line=":manage_crond: true"
+        dest=satellite_maintain_yml, insertafter="EOF", line=":manage_crond: true"
     )
 
     def sync_plan():
@@ -207,7 +207,7 @@ def setup_sync_plan(request, ansible_module):
         for path in ["/tmp/sync_id.yaml", "/tmp/orgs.yaml"]:
             ansible_module.file(path=path, state="absent")
         ansible_module.lineinfile(
-            dest=foreman_maintain_yml, state="absent", line=":manage_crond: true"
+            dest=satellite_maintain_yml, state="absent", line=":manage_crond: true"
         )
 
     return sync_plan
@@ -555,7 +555,7 @@ def setup_custom_package(request, ansible_module):
 
 @pytest.fixture(scope="function")
 def change_admin_passwd(request, setup_install_pexpect, ansible_module):
-    """Setup/Teardown for test_advanced.test_positive_foreman_maintain_hammer_setup"""
+    """Setup/Teardown for test_advanced.test_positive_satellite_maintain_hammer_setup"""
     setup = ansible_module.command(
         "hammer -u admin -p changeme user update --login admin --password admin"
     )

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -20,10 +20,10 @@ def test_positive_foreman_maintain_service_restart(ansible_module):
     :id: 64d3c78e-d602-43d6-bf77-f31135ed019e
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain advanced procedure run service-restart
+        1. Run satellite-maintain advanced procedure run service-restart
 
     :expectedresults: Katello-service should restart.
 
@@ -41,7 +41,7 @@ def test_positive_foreman_maintain_hammer_setup(change_admin_passwd, ansible_mod
     :id: 236171c0-5185-465e-9eec-e15dfefb41c3
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
         1. Change password for user to any string
@@ -101,10 +101,10 @@ def test_positive_foreman_maintain_packages_update(ansible_module):
     :id: d56523d7-7042-40e1-a96e-db8f33b960e5
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain advanced procedure run packages-update
+        1. Run satellite-maintain advanced procedure run packages-update
 
     :expectedresults: packages should update.
 
@@ -122,10 +122,10 @@ def test_positive_foreman_taks_delete_old(ansible_module):
     :id: c5deaf67-8fa9-43a6-bf62-1c0d6be63a85
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain advanced procedure run
+        1. Run satellite-maintain advanced procedure run
         foreman-tasks-delete --state old
 
     :expectedresults: Old foreman tasks should delete.
@@ -144,10 +144,10 @@ def test_positive_foreman_taks_delete_planning(ansible_module):
     :id: 447f5b05-b6a2-4f3a-8e89-8281995ca1cf
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain advanced procedure run
+        1. Run satellite-maintain advanced procedure run
         foreman-tasks-delete --state planning
 
     :expectedresults: foreman tasks in planning state should delete.
@@ -166,10 +166,10 @@ def test_positive_foreman_taks_delete_pending(ansible_module):
     :id: 6bd3af66-9910-48c4-8cbb-69c3ddd18d6c
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain advanced procedure run
+        1. Run satellite-maintain advanced procedure run
         foreman-tasks-delete --state pending
 
     :expectedresults: foreman tasks in pending state should delete.
@@ -188,7 +188,7 @@ def test_positive_foreman_task_resume(ansible_module):
     :id: e9afe55b-e3a4-425a-8bfd-a8df6674e516
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
         1. Run foreman-maintain advanced procedure run

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -14,7 +14,7 @@ from testfm.helpers import server
 from testfm.log import logger
 
 
-def test_positive_foreman_maintain_service_restart(ansible_module):
+def test_positive_satellite_maintain_service_restart(ansible_module):
     """Restart service using advanced procedure run
 
     :id: 64d3c78e-d602-43d6-bf77-f31135ed019e
@@ -35,7 +35,7 @@ def test_positive_foreman_maintain_service_restart(ansible_module):
         assert "FAIL" not in result["stdout"]
 
 
-def test_positive_foreman_maintain_hammer_setup(change_admin_passwd, ansible_module):
+def test_positive_satellite_maintain_hammer_setup(change_admin_passwd, ansible_module):
     """Hammer setup using advanced procedure
 
     :id: 236171c0-5185-465e-9eec-e15dfefb41c3
@@ -95,7 +95,7 @@ def test_positive_foreman_maintain_hammer_setup(change_admin_passwd, ansible_mod
 
 
 @stubbed
-def test_positive_foreman_maintain_packages_update(ansible_module):
+def test_positive_satellite_maintain_packages_update(ansible_module):
     """Packages update using advanced procedure run
 
     :id: d56523d7-7042-40e1-a96e-db8f33b960e5
@@ -191,7 +191,7 @@ def test_positive_foreman_task_resume(ansible_module):
         1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain advanced procedure run
+        1. Run satellite-maintain advanced procedure run
         foreman-tasks-resume
 
     :expectedresults: foreman tasks in paused state should resume.
@@ -210,10 +210,10 @@ def test_positive_foreman_tasks_ui_investigate(setup_install_pexpect, ansible_mo
     :id: 3b4f69c6-c0a1-42e3-a099-8a6e26280d17
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain advanced procedure run
+        1. Run satellite-maintain advanced procedure run
         foreman-tasks-ui-investigate
 
     :expectedresults: procedure foreman-tasks-ui-investigate should work.
@@ -236,12 +236,12 @@ def test_positive_sync_plan_disable_enable(setup_sync_plan, ansible_module):
     :id: 865df1e1-1189-437c-8451-22d772ff97d4
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain advanced procedure run
+        1. Run satellite-maintain advanced procedure run
         sync-plans-disable
-        2. Run foreman-maintain advanced procedure run
+        2. Run satellite-maintain advanced procedure run
         sync-plans-enable
 
     :expectedresults: procedure sync-plans-enable should work.
@@ -280,13 +280,13 @@ def test_positive_procedure_by_tag_check_migrations(ansible_module):
     :id: 65cacca0-f142-4a63-a644-01f76120f16c
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain advanced procedure by-tag
+        1. Run satellite-maintain advanced procedure by-tag
         pre-migrations
 
-        2. Run foreman-maintain advanced procedure by-tag
+        2. Run satellite-maintain advanced procedure by-tag
         post-migrations
 
     :expectedresults: procedures of pre-migrations tag and
@@ -319,10 +319,10 @@ def test_positive_procedure_by_tag_restore_confirmation(ansible_module):
     :id: f9e10352-04fb-49ba-8346-5b02e64fd028
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain advanced procedure by-tag
+        1. Run satellite-maintain advanced procedure by-tag
         restore
 
     :expectedresults: procedure restore_confirmation should work.
@@ -343,12 +343,12 @@ def test_positive_sync_plan_with_hammer_defaults(setup_for_hammer_defaults, ansi
     :id: b25734c8-470f-4cad-bc56-5c0f75aa7499
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
         1. Setup hammer on system with defaults set
 
-        2. Run foreman-maintain advanced procedure run sync-plans-enable
+        2. Run satellite-maintain advanced procedure run sync-plans-enable
 
     :expectedresults: sync plans should get disabled and enabled.
 
@@ -372,10 +372,10 @@ def test_positive_satellite_repositories_setup(setup_subscribe_to_cdn_dogfood, a
     :id: e32fee2d-2a1f-40ed-9f94-515f75511c5a
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run 'foreman-maintain advanced procedure run repositories-setup --version 6.y
+        1. Run satellite-maintain advanced procedure run repositories-setup --version 6.y
 
     :BZ: 1684730, 1869731
 
@@ -430,10 +430,10 @@ def test_positive_capsule_repositories_setup(setup_subscribe_to_cdn_dogfood, ans
     :id: 88558fb0-2268-469f-86ae-c4d18ccef782
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run 'foreman-maintain advanced procedure run repositories-setup --version 6.y
+        1. Run satellite-maintain advanced procedure run repositories-setup --version 6.y
 
     :BZ: 1684730, 1869731
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -49,9 +49,9 @@ def test_positive_backup_online(setup_backup_tests, ansible_module):
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain backup online /backup_dir/
+        1. Run satellite-maintain backup online /backup_dir/
 
     :expectedresults: Backup should successful.
 
@@ -85,9 +85,9 @@ def test_positive_backup_online_skip_pulp_content(setup_backup_tests, ansible_mo
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain backup online --skip-pulp-content /backup_dir/
+        1. Run satellite-maintain backup online --skip-pulp-content /backup_dir/
 
     :expectedresults: Backup should successful.
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -124,9 +124,9 @@ def test_positive_backup_online_preserve_directory(setup_backup_tests, ansible_m
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain backup online --preserve-directory /backup_dir/
+        1. Run satellite-maintain backup online --preserve-directory /backup_dir/
 
     :expectedresults: Backup should successful.
 
@@ -160,9 +160,9 @@ def test_positive_backup_online_split_pulp_tar(setup_backup_tests, ansible_modul
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain backup online  --split-pulp-tar 1M /backup_dir/
+        1. Run satellite-maintain backup online  --split-pulp-tar 1M /backup_dir/
 
     :expectedresults: Backup should successful.
 
@@ -197,10 +197,10 @@ def test_positive_backup_online_incremental(setup_backup_tests, ansible_module):
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. Take backup of server.
     :steps:
-        1. Run foreman-maintain backup online --incremental
+        1. Run satellite-maintain backup online --incremental
         /previous_backup_dir/ /backup_dir/
 
     :expectedresults: Backup should successful.
@@ -239,9 +239,9 @@ def test_positive_backup_online_caspule_features(setup_backup_tests, ansible_mod
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain backup online  --features dns,tftp /backup_dir/
+        1. Run satellite-maintain backup online  --features dns,tftp /backup_dir/
 
     :expectedresults: Backup should successful.
 
@@ -276,10 +276,10 @@ def test_positive_backup_online_all(setup_backup_tests, ansible_module):
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. Take backup of server.
     :steps:
-        1. Run foreman-maintain backup online -y -f -s -p -t 10M -i
+        1. Run satellite-maintain backup online -y -f -s -p -t 10M -i
         /previous_backup/ --features dns,tftp /backup_dir/
 
     :expectedresults: Backup should successful.
@@ -319,9 +319,9 @@ def test_positive_backup_offline(setup_backup_tests, ansible_module):
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain backup offline /backup_dir/
+        1. Run satellite-maintain backup offline /backup_dir/
 
     :expectedresults: Backup should successful.
 
@@ -352,9 +352,9 @@ def test_positive_backup_offline_skip_pulp_content(setup_backup_tests, ansible_m
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain backup offline --skip-pulp-content /backup_dir/
+        1. Run satellite-maintain backup offline --skip-pulp-content /backup_dir/
 
     :expectedresults: Backup should successful.
 
@@ -388,9 +388,9 @@ def test_positive_backup_offline_preserve_directory(setup_backup_tests, ansible_
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain backup offline --preserve-directory
+        1. Run satellite-maintain backup offline --preserve-directory
         /backup_dir/
 
     :expectedresults: Backup should successful.
@@ -422,9 +422,9 @@ def test_positive_backup_offline_split_pulp_tar(setup_backup_tests, ansible_modu
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain backup offline --split-pulp-tar 10M
+        1. Run satellite-maintain backup offline --split-pulp-tar 10M
         /backup_dir/
 
     :expectedresults: Backup should successful.
@@ -457,10 +457,10 @@ def test_positive_backup_offline_incremental(setup_backup_tests, ansible_module)
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. Take offline backup of server
     :steps:
-        1. Run foreman-maintain backup offline --incremental /previous_backup/
+        1. Run satellite-maintain backup offline --incremental /previous_backup/
         /backup_dir/
 
     :expectedresults: Backup should successful.
@@ -499,9 +499,9 @@ def test_positive_backup_offline_capsule_features(setup_backup_tests, ansible_mo
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain backup offline --features dns,tftp
+        1. Run satellite-maintain backup offline --features dns,tftp
         /backup_dir/
 
     :expectedresults: Backup should successful.
@@ -534,9 +534,9 @@ def test_positive_backup_offline_logical(setup_backup_tests, ansible_module):
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain backup offline --include-db-dumps /backup_dir/
+        1. Run satellite-maintain backup offline --include-db-dumps /backup_dir/
 
     :expectedresults: Backup should successful.
 
@@ -571,11 +571,11 @@ def test_positive_backup_offline_all(setup_backup_tests, ansible_module):
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. Take offline backup of server.
 
     :steps:
-        1. Run foreman-maintain backup offline -y -f -s -p -t 10M -i
+        1. Run satellite-maintain backup offline -y -f -s -p -t 10M -i
         /prevoius_backup/ --features dns,tfp --include-db-dumps /backup_dir/
 
     :expectedresults: Backup should successful.
@@ -616,9 +616,9 @@ def test_negative_backup_online_nodir(ansible_module):
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain backup online without providing
+        1. Run satellite-maintain backup online without providing
         directory
 
     :expectedresults: backup aborted, relevant message is
@@ -641,9 +641,9 @@ def test_negative_backup_offline_nodir(ansible_module):
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain backup offline without providing
+        1. Run satellite-maintain backup offline without providing
         directory
 
     :expectedresults: backup aborted, relevant message is
@@ -666,9 +666,9 @@ def test_negative_backup_online_incremental_nodir(ansible_module):
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain backup offline with nonexistent
+        1. Run satellite-maintain backup offline with nonexistent
         directory
 
     :expectedresults: backup aborted, relevant message is

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -8,16 +8,16 @@ from testfm.log import logger
 
 
 @pytest.mark.capsule
-def test_positive_foreman_maintain_health_list(ansible_module):
-    """List health check in foreman-maintain
+def test_positive_satellite_maintain_health_list(ansible_module):
+    """List health check in satellite-maintain
 
     :id: 976ef4cd-e028-4545-91bb-72433d40d7ee
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain health list
+        1. Run satellite-maintain health list
 
     :expectedresults: Health check list should work.
 
@@ -30,16 +30,16 @@ def test_positive_foreman_maintain_health_list(ansible_module):
 
 
 @pytest.mark.capsule
-def test_positive_foreman_maintain_health_list_tags(ansible_module):
-    """List tags for health check in foreman-maintain
+def test_positive_satellite_maintain_health_list_tags(ansible_module):
+    """List tags for health check in satellite-maintain
 
     :id: d0a6c8c1-8266-464a-bfdf-01d405dd9bd2
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain health list-tags
+        1. Run satellite-maintain health list-tags
 
     :expectedresults: Tags for health checks should list.
 
@@ -53,15 +53,15 @@ def test_positive_foreman_maintain_health_list_tags(ansible_module):
 
 @pytest.mark.capsule
 def test_positive_list_health_check_by_tags(ansible_module):
-    """List health check in foreman-maintain by tags
+    """List health check in satellite-maintain by tags
 
     :id: 420d8e62-84d8-4496-8c24-037bd23febe9
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain health list --tags default
+        1. Run satellite-maintain health list --tags default
 
     :expectedresults: health checks according to tag should list.
 
@@ -75,16 +75,16 @@ def test_positive_list_health_check_by_tags(ansible_module):
 
 
 @pytest.mark.capsule
-def test_positive_foreman_maintain_health_check(ansible_module):
-    """Verify foreman-maintain health check
+def test_positive_satellite_maintain_health_check(ansible_module):
+    """Verify satellite-maintain health check
 
     :id: bfff93dd-adde-4630-8411-1bb6b74daddd
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain health check
+        1. Run satellite-maintain health check
 
     :expectedresults: Health check should perform.
 
@@ -99,16 +99,16 @@ def test_positive_foreman_maintain_health_check(ansible_module):
 
 
 @pytest.mark.capsule
-def test_positive_foreman_maintain_health_check_by_tags(ansible_module):
-    """Verify foreman-maintain health check by tags
+def test_positive_satellite_maintain_health_check_by_tags(ansible_module):
+    """Verify satellite-maintain health check by tags
 
     :id: 518e19af-2dd4-4fb0-8c90-208cbd354107
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain health check --tags tag_name
+        1. Run satellite-maintain health check --tags tag_name
 
     :expectedresults: Health check should perform.
 
@@ -132,10 +132,10 @@ def test_positive_check_server_ping(ansible_module):
     :id: b1eec8cb-9f94-439a-b5e7-8621cb35501f
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain health check --label server-ping
+        1. Run satellite-maintain health check --label server-ping
 
     :expectedresults: Health check should perform.
 
@@ -153,11 +153,11 @@ def test_negative_check_server_ping(setup_katello_service_stop, ansible_module):
     :id: ecdc5bfb-2adf-49f6-948d-995dae34bcd3
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
         1. Run Katello-service stop
-        2. Run foreman-maintain health check --label server-ping
+        2. Run satellite-maintain health check --label server-ping
         3. Run Katello-service start
 
     :expectedresults: Health check should perform.
@@ -177,10 +177,10 @@ def test_positive_pre_upgrade_health_check(ansible_module):
     :id: f52bd43e-79cd-488b-adbb-3c9e5bac32cc
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain health check --tags pre-upgrade
+        1. Run satellite-maintain health check --tags pre-upgrade
 
     :expectedresults: Pre-upgrade health checks should perform.
 
@@ -199,10 +199,10 @@ def test_positive_check_upstream_repository(setup_upstream_repository, ansible_m
     :id: 349fcf33-2d25-4628-a6af-cff53e624b25
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain health check --label check-upstream-repository
+        1. Run satellite-maintain health check --label check-upstream-repository
 
     :expectedresults: Health check should perform.
 
@@ -224,10 +224,10 @@ def test_positive_available_space(ansible_module):
     :id: 7d8798ca-3334-4dda-a9b0-dc3d7c0903e9
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain health check --label available-space
+        1. Run satellite-maintain health check --label available-space
 
     :expectedresults: Health check should perform.
 
@@ -246,10 +246,10 @@ def test_positive_available_space_candlepin(ansible_module):
     :id: 382a2bf3-a3da-4e46-b370-a443450f93b7
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain health check --label available-space-cp
+        1. Run satellite-maintain health check --label available-space-cp
 
     :expectedresults: Health check should perform.
 
@@ -269,12 +269,12 @@ def test_positive_automate_bz1632768(setup_hammer_defaults, ansible_module):
     :id: 27a8b49b-8cb8-4004-ba41-36ed084c4740
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
         1. Setup hammer on system with defaults set
 
-        2. Run foreman-maintain health check
+        2. Run satellite-maintain health check
 
     :expectedresults: Health check should perform.
 
@@ -296,10 +296,10 @@ def test_positive_puppet_check_no_empty_cert_requests(ansible_module):
     :id: aad69254-9978-41e7-83a9-122e342a8dc5
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain health check --label puppet-check-no-empty-cert-requests
+        1. Run satellite-maintain health check --label puppet-check-no-empty-cert-requests
 
     :expectedresults: Health check should perform.
 
@@ -321,11 +321,11 @@ def test_positive_puppet_check_empty_cert_requests(setup_puppet_empty_cert, ansi
     :id: d4b9f725-d764-475a-9fc0-8db4aa1cb6ce
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. have some empty files in ${puppet-check-no-empty-cert-requests}
 
     :steps:
-        1. Run foreman-maintain health check --label puppet-check-no-empty-cert-requests
+        1. Run satellite-maintain health check --label puppet-check-no-empty-cert-requests
 
     :expectedresults: Health check should perform.
 
@@ -354,12 +354,12 @@ def test_positive_check_hotfix_installed(setup_hotfix_check, ansible_module):
     :id: d9023293-4173-4223-bbf5-328b41cf87cd
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
         2. modify some files of satellite.
 
     :steps:
-        1. Run foreman-maintain health check --label check-hotfix-installed
+        1. Run satellite-maintain health check --label check-hotfix-installed
 
     :expectedresults: check-hotfix-installed check should detect modified file
         and installed hotfix.
@@ -386,11 +386,11 @@ def test_positive_check_hotfix_installed_without_hotfix(ansible_module):
     :id: 3b6fbf3a-5c78-4283-996e-ca8da88a5d1b
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
         2. Install python-kitchen, yum-utils packages.
     :steps:
-        1. Run foreman-maintain health check --label check-hotfix-installed
+        1. Run satellite-maintain health check --label check-hotfix-installed
 
     :expectedresults: Health check should perform.
 
@@ -414,11 +414,11 @@ def test_positive_check_validate_yum_config(ansible_module):
     :id: b50c8866-6175-4286-8106-561945726023
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
         1. configure yum exclude.
-        2. Run foreman-maintain health check --label validate-yum-config
+        2. Run satellite-maintain health check --label validate-yum-config
         3. Assert that excluded packages are listed in output.
         4. remove yum exclude configured in step 1.
 
@@ -465,11 +465,11 @@ def test_positive_check_epel_repository(setup_epel_repository, ansible_module):
     :id: ce2d7278-d7b7-4f76-9923-79be831c0368
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
         1. Configure epel repository.
-        2. Run foreman-maintain health check --label check-non-redhat-repository.
+        2. Run satellite-maintain health check --label check-non-redhat-repository.
         3. Assert that EPEL repos are enabled on system.
 
     :BZ: 1755755
@@ -496,11 +496,11 @@ def test_positive_check_epel_repository_with_invalid_repo(
     :id: e41648f4-ada6-4e7e-9112-45146d308410
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
         1. Configure epel repository and a repository with invalid baseurl.
-        2. Run foreman-maintain health check --label check-non-redhat-repository.
+        2. Run satellite-maintain health check --label check-non-redhat-repository.
         3. Assert that EPEL repos are enabled on system.
 
     :BZ: 1755755
@@ -523,12 +523,12 @@ def test_positive_check_old_foreman_tasks(setup_old_foreman_tasks, ansible_modul
     :id: 156350c4-b55b-40b3-b8f2-202bd5ed9fb6
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. Run setup_old_foreman_tasks from conftest.py
 
     :steps:
         1. Configure epel repository.
-        2. Run foreman-maintain health check --label check-non-redhat-repository.
+        2. Run satellite-maintain health check --label check-non-redhat-repository.
         3. Assert that old tasks are found on system.
         4. Assert that old tasks are deleted from system.
 
@@ -563,14 +563,14 @@ def test_positive_check_tmout_variable(ansible_module):
     :id: e0eea928-0ffb-4692-adb9-fc4bf041f301
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. export TMOUT environment variable.
 
     :steps:
-        1. Run foreman-maintain health check --label check-tmout-variable.
+        1. Run satellite-maintain health check --label check-tmout-variable.
         2. Assert that check-tmout-variable pass.
         3. export TMOUT environment variable.
-        4. Run foreman-maintain health check --label check-tmout-variable.
+        4. Run satellite-maintain health check --label check-tmout-variable.
         5. Assert that check-tmout-variable fails.
 
     :expectedresults: check-tmout-variable should work.
@@ -603,15 +603,15 @@ def test_positive_check_tftp_storage(ansible_module, setup_tftp_storage):
     :id: 9a900bc7-65ff-4280-bf8a-8974a7cb76c6
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
         1. Create test files in /var/lib/tftpboot/boot/
-        2. Run foreman-maintain health check --label check-tftp-storage.
+        2. Run satellite-maintain health check --label check-tftp-storage.
         3. Assert that check-tftp-storage fails.
         4. Assert that check deletes files older than token_duration setting.
         5. Delete all files from /var/lib/tftpboot/boot/
-        6. Run foreman-maintain health check --label check-tftp-storage.
+        6. Run satellite-maintain health check --label check-tftp-storage.
         7. Assert that check-tftp-storage pass.
 
     :expectedresults: check-tftp-storage should work.
@@ -664,22 +664,22 @@ def test_positive_check_postgresql_checkpoint_segments(ansible_module):
     :id: 963a5b47-168a-4443-9fdf-bba59c9b0e97
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
         1. Have an invalid /etc/foreman-installer/custom-hiera.yaml file
-        2. Run foreman-maintain health check --label check-postgresql-checkpoint-segments.
+        2. Run satellite-maintain health check --label check-postgresql-checkpoint-segments.
         3. Assert that check-postgresql-checkpoint-segments gives proper
            error message saying an invalid yaml file
         4. Make /etc/foreman-installer/custom-hiera.yaml file valid
         5. Add config_entries section in /etc/foreman-installer/custom-hiera.yaml
-        6. Run foreman-maintain health check --label check-postgresql-checkpoint-segments.
+        6. Run satellite-maintain health check --label check-postgresql-checkpoint-segments.
         7. Assert that check-postgresql-checkpoint-segments fails.
         8. Add checkpoint_segments parameter in /etc/foreman-installer/custom-hiera.yaml
-        9. Run foreman-maintain health check --label check-postgresql-checkpoint-segments.
+        9. Run satellite-maintain health check --label check-postgresql-checkpoint-segments.
         10. Assert that check-postgresql-checkpoint-segments fails.
         11. Remove config_entries section from /etc/foreman-installer/custom-hiera.yaml
-        12. Run foreman-maintain health check --label check-postgresql-checkpoint-segments.
+        12. Run satellite-maintain health check --label check-postgresql-checkpoint-segments.
         13. Assert that check-postgresql-checkpoint-segments pass.
 
     :BZ: 1894149, 1899322
@@ -764,13 +764,13 @@ def test_positive_check_env_proxy(ansible_module):
     :id: f8c44b40-3ce5-4179-8d6b-1156c0032450
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
         1. export HTTP_PROXY environment variable.
-        2. Run foreman-maintain health check --label env-proxy.
+        2. Run satellite-maintain health check --label env-proxy.
         3. Assert that check env-proxy fail.
-        4. Run foreman-maintain health check --label env-proxy.
+        4. Run satellite-maintain health check --label env-proxy.
         5. Assert that check env-proxy pass.
 
     :expectedresults: check env-proxy should work.
@@ -802,15 +802,15 @@ def test_positive_check_foreman_proxy_verify_dhcp_config_syntax(ansible_module):
     :id: 43ca5cc7-9888-490d-b1ba-f3298e737039
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. Satellite instance configured with external DHCP like Infoblox,
            which has `:use_provider: dhcp_infoblox` set in /etc/foreman-proxy/settings.d/dhcp.yml
         3. Satellite instance which is DHCP enabled and has `:use_provider: dhcp_isc`
            set in /etc/foreman-proxy/settings.d/dhcp.yml
 
     :steps:
-        1. foreman-maintain health list | grep foreman-proxy-verify-dhcp-config-syntax
-        2. foreman-maintain health check --label foreman-proxy-verify-dhcp-config-syntax
+        1. satellite-maintain health list | grep foreman-proxy-verify-dhcp-config-syntax
+        2. satellite-maintain health check --label foreman-proxy-verify-dhcp-config-syntax
 
     :BZ: 1847889
 
@@ -828,11 +828,11 @@ def test_positive_remove_job_file(setup_subscribe_to_cdn_dogfood, ansible_module
     :id: eed224f9-a2ec-4d15-9047-cede0b823866
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain health list --tags pre-upgrade
-        2. Run foreman-maintain health check --label disk-performance
+        1. Run satellite-maintain health list --tags pre-upgrade
+        2. Run satellite-maintain health check --label disk-performance
 
     :expectedresults: `disk-performance` shouldn't exist under pre-upgrade tag and
             /var/lib/pulp/job1.0.0 file should not exist after check execution
@@ -859,12 +859,12 @@ def test_positive_corrupted_roles(ansible_module, setup_corrupted_role):
     :id: 69d9ac9e-772c-42e8-94b6-e8561c70c5c0
 
      :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. Run "hammer filter list --search role=test_role" to Check the role,
            resource type, and permissions assigned.
 
     :steps:
-        1. Run foreman-maintain health check --label corrupted-roles
+        1. Run satellite-maintain health check --label corrupted-roles
         2. Run "hammer filter list --search role=test_role" again to check if corrupted roles
            are fixed and verify if new filter is created for updated resource_type
 
@@ -902,11 +902,11 @@ def test_positive_check_non_rh_packages(setup_custom_package, ansible_module):
     :id: 2b7a25bb-902c-4a87-bb71-f460dcce655c
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. Configure custom repository and install custom package
 
     :steps:
-        1. Run foreman-maintain health check --label non-rh-packages.
+        1. Run satellite-maintain health check --label non-rh-packages.
         2. Verify presense of non-RH/custom package installed on system.
 
     :BZ: 1869865
@@ -932,13 +932,13 @@ def test_positive_available_space_postgresql12(ansible_module):
     :id: 283e627d-6afc-49cb-afdb-5b77a91bbd1e
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. Have some data under /var/lib/pgsql (upgrade templates have ~565Mib data)
         3. Create dir /var/opt/rh/rh-postgresql12/ and mount a partition of ~300Mib
            to this dir (less than /var/lib/pgsql).
 
     :steps:
-        1. foreman-maintain health check --label available-space-for-postgresql12
+        1. satellite-maintain health check --label available-space-for-postgresql12
         2. Verify Warning or Error is displayed when enough space is not
            available under /var/opt/rh/rh-postgresql12/
 

--- a/tests/test_maintenance_mode.py
+++ b/tests/test_maintenance_mode.py
@@ -5,12 +5,12 @@ from testfm.maintenance_mode import MaintenanceMode
 
 
 def test_positive_maintenance_mode(setup_sync_plan, ansible_module):
-    """Test foreman-maintain maintenance-mode subcommand
+    """Test satellite-maintain maintenance-mode subcommand
 
     :id: 51d76219-d3cc-43c0-9894-7bcb75c163c3
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. active sync-plans
         3. set :manage_crond: true in /etc/foreman-maintain/foreman_maintain.yml'
 
@@ -29,7 +29,7 @@ def test_positive_maintenance_mode(setup_sync_plan, ansible_module):
         12. Validate maintenance-mode status command's output.
         13. Validate maintenance-mode is-enabled command's output.
 
-    :expectedresults: foreman-maintain maintenance-mode start/stop able
+    :expectedresults: satellite-maintain maintenance-mode start/stop able
         to disable/enable sync-plan, stop/start crond.service and is able to add
         FOREMAN_MAINTAIN chain rule in iptables.
 

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -12,16 +12,16 @@ def test_positive_fm_packages_lock(ansible_module):
     :id: d387d8be-10ad-4a62-aeff-3bc6a82e6bae
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain packages lock
-        2. Run foreman-maintain packages status
-        3. Run foreman-maintain packages is-locked
+        1. Run satellite-maintain packages lock
+        2. Run satellite-maintain packages status
+        3. Run satellite-maintain packages is-locked
         4. check 'satellite' is mentioned in /etc/yum/pluginconf.d/versionlock.list
-        5. Run foreman-maintain packages unlock
-        6. Run foreman-maintain packages status
-        7. Run foreman-maintain packages is-locked
+        5. Run satellite-maintain packages unlock
+        6. Run satellite-maintain packages status
+        7. Run satellite-maintain packages is-locked
         8. check 'satellite' is not mentioned in /etc/yum/pluginconf.d/versionlock.list
 
     :expectedresults: expected packages get locked and unlocked.
@@ -79,15 +79,15 @@ def test_positive_lock_package_versions(ansible_module):
     :id: 9218a718-038c-48bb-b4a4-d4cb74859ddb
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
         1. Run satellite-installer --lock-package-versions
-        2. Run foreman-maintain packages status
-        3. Run foreman-maintain packages is-locked
+        2. Run satellite-maintain packages status
+        3. Run satellite-maintain packages is-locked
         4. Run satellite-installer --no-lock-package-versions
-        5. Run foreman-maintain packages status
-        6. Run foreman-maintain packages is-locked
+        5. Run satellite-maintain packages status
+        6. Run satellite-maintain packages is-locked
         7. Teardown (Run satellite-installer --lock-package-versions)
 
     :expectedresults: expected packages get locked and unlocked.
@@ -142,16 +142,16 @@ def test_positive_fm_packages_install(ansible_module, setup_packages_lock_tests)
     :id: 645a3d84-34cb-469c-8b79-105b889aac78
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
         1. Run satellite-installer --lock-package-versions
-        2. Run foreman-maintain packages status
-        3. Run foreman-maintain packages is-locked
-        4. Try to install/update package using FM packages install/update command.
+        2. Run satellite-maintain packages status
+        3. Run satellite-maintain packages is-locked
+        4. Try to install/update package using satellite-maintain packages install/update command.
         5. Run satellite-installer --no-lock-package-versions
-        6. Run foreman-maintain packages status
-        7. Run foreman-maintain packages is-locked
+        6. Run satellite-maintain packages status
+        7. Run satellite-maintain packages is-locked
         8. Try to install package in unlocked state.
         9. Teardown (Run satellite-installer --lock-package-versions)
 
@@ -164,7 +164,7 @@ def test_positive_fm_packages_install(ansible_module, setup_packages_lock_tests)
     for result in contacted.values():
         assert result["rc"] == 1
         assert "Use foreman-maintain packages install/update <package>" in result["stdout"]
-    # Test whether FM packages install/ update command works as expected.
+    # Test whether satellite-maintain packages install/ update command works as expected.
     contacted = ansible_module.raw(
         Packages.install(["--assumeyes", "zsh-5.0.2-31.el7.x86_64 elinks"])
     )
@@ -214,28 +214,28 @@ def test_positive_fm_packages_update(ansible_module, setup_packages_update):
     :id: 354d9940-10f1-4244-9079-fdbd24be49b3
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain packages check-update
-        2. Run foreman-maintain packages update to update the walrus package.
+        1. Run satellite-maintain packages check-update
+        2. Run satellite-maintain packages update to update the walrus package.
         3. Verify walrus package is updated.
 
     :BZ: 1803975
 
-    :expectedresults: foreman-maintain packages check-update should list walrus package for update
-                      and foreman-maintain packages update should update the walrus package.
+    :expectedresults: satellite-maintain packages check-update should list walrus package for update
+                      and satellite-maintain packages update should update the walrus package.
 
     :CaseImportance: Critical
     """
-    # Run foreman-maintain packages check update and verify walrus package is available for update.
+    # Run satellite-maintain packages check update and verify walrus package is available for update
     contacted = ansible_module.command(Packages.check_update())
     for result in contacted.values():
         logger.info(result["stdout"])
         assert "FAIL" not in result["stdout"]
         assert result["rc"] == 0
         assert "walrus" in result["stdout"]
-    # Run foreman-maintain packages update
+    # Run satellite-maintain packages update
     contacted = ansible_module.raw(Packages.update(["--assumeyes", "walrus"]))
     for result in contacted.values():
         logger.info(result["stdout"])
@@ -257,10 +257,10 @@ def test_positive_fm_packages_sat_installer(ansible_module):
     :id: d73971a1-68b4-4ab2-a87c-76cc5ff80a39
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain packages install/update rubygem-foreman_maintain
+        1. Run satellite-maintain packages install/update rubygem-foreman_maintain
         2. Verify satellite-installer is not executed after install/update
            of rubygem-foreman_maintain package
 

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -17,10 +17,10 @@ def test_positive_restore_online_backup(ansible_module):
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. Take online backup of server.
     :steps:
-        1. Run foreman-maintain restore /backup_dir/
+        1. Run satellite-maintain restore /backup_dir/
 
     :expectedresults: Restore successful.
 
@@ -59,10 +59,10 @@ def test_positive_restore_offline_backup(ansible_module):
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. Take offline backup of server.
     :steps:
-        1. Run foreman-maintain restore /backup_dir/
+        1. Run satellite-maintain restore /backup_dir/
 
     :expectedresults: Restore successful.
 
@@ -100,10 +100,10 @@ def test_negative_restore_nodir(ansible_module):
     :id: c0eeb8fb-e6ca-40c7-8c25-b5a4e3cb7827
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain restore without providing
+        1. Run satellite-maintain restore without providing
         directory
 
     :expectedresults: restore aborted, relevant message is
@@ -125,10 +125,10 @@ def test_negative_restore_baddir(ansible_module):
     :id: 1ea94c42-6c33-4fd5-9fe5-c53036023418
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain restore providing
+        1. Run satellite-maintain restore providing
         invalid directory
 
     :expectedresults: restore aborted, relevant message is

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -179,7 +179,7 @@ def test_positive_automate_bz1626651(ansible_module):
 
 @pytest.mark.capsule
 def test_positive_service_status_clocale(ansible_module):
-    """Foreman-maintain service on C locale
+    """Satellite-maintain service on C locale
 
     :id: 143dda54-5ab5-478a-b33e-af805bace2d7
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -6,16 +6,16 @@ from testfm.service import Service
 
 
 @pytest.mark.capsule
-def test_positive_foreman_maintain_service_restart(ansible_module):
+def test_positive_satellite_maintain_service_restart(ansible_module):
     """Restart services using service restart
 
     :id: c5a38994-8c14-40c7-bc6a-1cfc68fc2d28
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain service restart
+        1. Run satellite-maintain service restart
 
     :expectedresults: Katello-services should restart.
 
@@ -29,16 +29,16 @@ def test_positive_foreman_maintain_service_restart(ansible_module):
 
 
 @pytest.mark.capsule
-def test_positive_foreman_maintain_service_start(ansible_module):
+def test_positive_satellite_maintain_service_start(ansible_module):
     """Start services using service start
 
     :id: fa3b02a9-b441-413b-b9d2-1a59d04f285c
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain service start
+        1. Run satellite-maintain service start
 
     :expectedresults: Katello-services should start.
 
@@ -57,12 +57,12 @@ def test_positive_foreman_service(ansible_module):
     :id: 08a29ea2-2e49-11eb-a22b-d46d6dd3b5b2
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
         1. Stop foreman service
         2. Check the status for httpd should not have affect
-        3. Run foreman-maintain health check
+        3. Run satellite-maintain health check
 
     :expectedresults: service should restart correctly.
 
@@ -94,15 +94,15 @@ def test_positive_foreman_service(ansible_module):
 
 @pytest.mark.capsule
 def test_positive_service_enable(ansible_module):
-    """Enable services using foreman-maintain service
+    """Enable services using satellite-maintain service
 
     :id: a0e0a052-0e21-465c-bb28-2e7613dbece6
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain service enable.
+        1. Run satellite-maintain service enable.
 
     :expectedresults: service should enable.
 
@@ -117,15 +117,15 @@ def test_positive_service_enable(ansible_module):
 
 @pytest.mark.capsule
 def test_positive_service_disable(ansible_module):
-    """Disable services using foreman-maintain service
+    """Disable services using satellite-maintain service
 
     :id: e2c052e5-c2b6-4f0e-952b-3b0c22c66f22
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain service disable.
+        1. Run satellite-maintain service disable.
 
     :expectedresults: service should disable.
 
@@ -145,16 +145,16 @@ def test_positive_service_disable(ansible_module):
 
 @pytest.mark.capsule
 def test_positive_automate_bz1626651(ansible_module):
-    """Disable services using foreman-maintain service
+    """Disable services using satellite-maintain service
 
     :id: dc60e388-f012-4164-a496-b12d6230cdc2
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain service stop.
-        2. Run foreman-maintain service restart
+        1. Run satellite-maintain service stop.
+        2. Run satellite-maintain service restart
 
     :expectedresults: service should restart.
 
@@ -184,10 +184,10 @@ def test_positive_service_status_clocale(ansible_module):
     :id: 143dda54-5ab5-478a-b33e-af805bace2d7
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run LC_ALL=C foreman-maintain service stop.
+        1. Run LC_ALL=C satellite-maintain service stop.
 
     :expectedresults: service status should display.
 
@@ -201,16 +201,16 @@ def test_positive_service_status_clocale(ansible_module):
 
 @pytest.mark.capsule
 def test_positive_failed_service_status(ansible_module):
-    """Verify foreman-maintain service status return error when service stopped
+    """Verify satellite-maintain service status return error when service stopped
 
     :id: 74f6e276-1e54-4bf3-9538-19e87059f8b5
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain service stop.
-        2. Run foreman-maintain service status.
+        1. Run satellite-maintain service stop.
+        2. Run satellite-maintain service status.
 
     :expectedresults: service status should return error code.
 
@@ -237,11 +237,11 @@ def test_positive_fm_service_restart_bz_1696862(setup_bz_1696862, ansible_module
     :id: c7518650-d72a-47b1-8d38-42b862f474fc
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
         2. Run setup_bz_1696862 from conftest.py
 
     :steps:
-        1. Run foreman-maintain service restart
+        1. Run satellite-maintain service restart
 
     :expectedresults: Katello-services should restart even
      if hammer credentials are not available.
@@ -257,17 +257,17 @@ def test_positive_fm_service_restart_bz_1696862(setup_bz_1696862, ansible_module
         assert result["rc"] == 0
 
 
-def test_positive_foreman_maintain_service_list_sidekiq(ansible_module):
+def test_positive_satellite_maintain_service_list_sidekiq(ansible_module):
     """List sidekiq services with service list
 
     :id: 5acb68a9-c430-485d-bb45-b499adc90927
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain service list
-        2. Run foreman-maintain service restart
+        1. Run satellite-maintain service list
+        2. Run satellite-maintain service restart
 
     :expectedresults: Sidekiq-services should list and should restart.
 
@@ -291,21 +291,21 @@ def test_positive_foreman_maintain_service_list_sidekiq(ansible_module):
 
 
 def test_positive_service_status_rpmsave(ansible_module, setup_rpmsave_file):
-    """Verify foreman-maintain service status doesn't pick up any backup files like .rpmsave,
+    """Verify satellite-maintain service status doesn't pick up any backup files like .rpmsave,
     or any file with .yml which don't exist as services.
 
     :id: dda696c9-7385-4450-8380-b694e4016661
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain service status.
-        2. Verify foreman-maintain service status doesn't pick up any backup files like
+        1. Run satellite-maintain service status.
+        2. Verify satellite-maintain service status doesn't pick up any backup files like
            .rpmsave, or any file with .yml which don't exist as services.
 
 
-    :expectedresults: foreman-maintain service status shouldn't pick
+    :expectedresults: satellite-maintain service status shouldn't pick
                       invalid services with extension .rpmsave
 
     :BZ: 1945916, 1962853

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -8,16 +8,16 @@ from testfm.upgrade import Upgrade
 
 
 @pytest.mark.capsule
-def test_positive_foreman_maintain_upgrade_list(ansible_module):
+def test_positive_satellite_maintain_upgrade_list(ansible_module):
     """List versions this system is upgradable to
 
     :id: 12efec41-4f09-4199-a20c-a4525e773b78
 
     :setup:
 
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
     :steps:
-        1. Run foreman-maintain upgrade list-versions
+        1. Run satellite-maintain upgrade list-versions
 
     :expectedresults: Versions system is upgradable to are listed.
 
@@ -68,10 +68,10 @@ def test_positive_repositories_validate(ansible_module):
     :id: 811698c0-09da-4727-8886-077aebb2b5ed
 
     :setup:
-        1. foreman-maintain should be installed.
+        1. satellite-maintain should be installed.
 
     :steps:
-        1. Run foreman-maintain upgrade check.
+        1. Run satellite-maintain upgrade check.
 
     :BZ: 1632111
 
@@ -101,22 +101,22 @@ def test_positive_repositories_validate(ansible_module):
 @pytest.mark.capsule
 @stubbed
 def test_positive_self_update():
-    """Test self-update foreman-maintain package feature.
+    """Test self-update satellite-maintain package feature.
 
     :id: 1c566768-fd73-4fe6-837b-26709a1ebed9
 
     :setup:
-        1. foreman-maintain should be installed.
-        2. foreman-maintain package version should be >= v0.6.x
+        1. satellite-maintain should be installed.
+        2. satellite-maintain package version should be >= v0.6.x
 
     :steps:
-        1. Run foreman-maintain upgrade check/run command.
-        2. Run foreman-maintain upgrade check/run command with disable-self-upgrade option.
+        1. Run satellite-maintain upgrade check/run command.
+        2. Run satellite-maintain upgrade check/run command with disable-self-upgrade option.
 
     :BZ: 1649329
 
     :expectedresults:
-        1. It updates FM to latest version and gives message to re-run command.
+        1. Update satellite-maintain package to latest version and gives message to re-run command.
         2. If disable-self-upgrade option is used then it should skip self-upgrade step.
 
     :CaseImportance: Critical
@@ -131,12 +131,12 @@ def test_positive_check_presence_satellite_or_satellite_capsule():
     :id: 1011ff01-6dfb-422f-92c5-995d38bc163e
 
     :setup:
-        1. foreman-maintain should be installed.
-        2. foreman-maintain package version should be >= v0.6.x
+        1. satellite-maintain should be installed.
+        2. satellite-maintain package version should be >= v0.6.x
 
     :steps:
-        1. Run foreman-maintain upgrade list-versions/check/run command.
-        2. Run foreman-maintain upgrade list-versions/check/run command,
+        1. Run satellite-maintain upgrade list-versions/check/run command.
+        2. Run satellite-maintain upgrade list-versions/check/run command,
             after removing satellite and satellite-capsule packages.
 
     :BZ: 1886031


### PR DESCRIPTION
we should use downstream name

it is just symlink
```
ls -l /usr/bin/satellite-maintain
....  /usr/bin/satellite-maintain -> /usr/bin/foreman-maintain
```
