### PR TITLE
Change pip installation method for setup_install_pexpect

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,19 +144,13 @@ def setup_install_pexpect(ansible_module, request):
     test_positive_check_old_foreman_tasks of test_advanced.py and in
     fixture setup_puppet_empty_cert.
     """
-    ansible_module.get_url(url="https://bootstrap.pypa.io/get-pip.py", dest="/root")
-    setup = ansible_module.command("python3 /root/get-pip.py")
-    for result in setup.values():
-        assert result["rc"] == 0
-    setup = ansible_module.command("pip install pexpect")
+    setup = ansible_module.command("python3 -m pip install pexpect")
     for result in setup.values():
         assert result["rc"] == 0
 
     def teardown_uninstall():
-        uninstall_pexpect = ansible_module.command("pip uninstall pexpect -y")
+        uninstall_pexpect = ansible_module.command("python3 -m pip uninstall pexpect -y")
         assert uninstall_pexpect.values()[0]["rc"] == 0
-        uninstall_pip = ansible_module.command("pip uninstall pip -y")
-        assert uninstall_pip.values()[0]["rc"] == 0
 
     request.addfinalizer(teardown_uninstall)
 


### PR DESCRIPTION
The minimum supported version for get-pip is updated to python3.7, and both el7 and el8 have the default python3 version as 3.6, so instead of changing the URL for a get-pip script, proposing changing the installation method using the python3 command.

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>