### PR TITLE
Remove 6.7 from test_positive_satellite_repositories_setup

### DIFF
--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -382,7 +382,7 @@ def test_positive_satellite_repositories_setup(setup_subscribe_to_cdn_dogfood, a
 
     :CaseImportance: Critical
     """
-    for ver in ["6.7", "6.8", "6.9", "6.10"]:
+    for ver in ["6.8", "6.9", "6.10"]:
         contacted = ansible_module.command(Advanced.run_repositories_setup({"version": ver}))
         for result in contacted.values():
             logger.info(result["stdout"])


### PR DESCRIPTION
Missed here https://github.com/SatelliteQE/testfm/pull/273/files

**Tests Results:**
```
$ pytest -q --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory tests/test_advanced.py -k test_positive_satellite_repositories_setup
.                                                                                                                                 [100%]
1 passed, 13 deselected in 800.01 seconds
```


Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>