### PR TITLE
Remove HOTFIX_URL setting and use REPOS_HOSTING_URL instead

### DIFF
--- a/conf/testfm.sample.yaml
+++ b/conf/testfm.sample.yaml
@@ -1,7 +1,7 @@
 # copy this file as `testfm.local.yaml` and override any config provided under `conf/*.yaml`
 # or preferably use environment variables instead of this file
 # example:
-# `export TESTFM_TESTFM__HOTFIX_URL=<HOTFIX_URL>`
+# `export TESTFM_SUBSCRIPTION__RHN_PASSWORD=<RHN_PASSWORD>`
 ---
 # copy SUBSCRIPTION section from subscription.yaml or keep subscription.yaml under conf/
 # SUBSCRIPTION:
@@ -12,5 +12,13 @@
   # DOGFOOD_ORG: <DOGFOOD_ORG>
   # DOGFOOD_ACTIVATIONKEY: <DOGFOOD_ACTIVATIONKEY>
   # CAPSULE_DOGFOOD_ACTIVATIONKEY: <CAPSULE_DOGFOOD_ACTIVATIONKEY>
-# TESTFM:
-  # HOTFIX_URL: <HOTFIX_URL>
+
+# copy ROBOTTELO section from robottelo.yaml or keep robottelo.yaml under conf/
+# ROBOTTELO:
+  # - The URL of container hosting repos on SatLab
+  # REPOS_HOSTING_URL: <repo_hosting_url>
+  # Satellite version supported by this branch
+  # Set this via envvar when building robottelo-container for z-stream branches
+  # SATELLITE_VERSION: '7.0'
+  # The Base OS RHEL Version(x.y) where the satellite would be installed
+  # RHEL_VERSION: '7.9'

--- a/testfm/__init__.py
+++ b/testfm/__init__.py
@@ -19,7 +19,6 @@ settings = Dynaconf(
             "subscription.dogfood_activationkey",
             "subscription.capsule_dogfood_activationkey",
             "subscription.dogfood_url",
-            "testfm.hotfix_url",
             must_exist=True,
         )
     ],

--- a/testfm/constants.py
+++ b/testfm/constants.py
@@ -7,8 +7,8 @@ DOGFOOD_ORG = settings.subscription.dogfood_org
 DOGFOOD_ACTIVATIONKEY = settings.subscription.dogfood_activationkey
 CAPSULE_DOGFOOD_ACTIVATIONKEY = settings.subscription.capsule_dogfood_activationkey
 DOGFOOD_URL = settings.subscription.dogfood_url
-HOTFIX_URL = settings.testfm.hotfix_url
 REPOS_HOSTING_URL = settings.robottelo.repos_hosting_url
+HOTFIX_URL = f"{REPOS_HOSTING_URL}/hotfix_package/"
 FAKE_YUM0_REPO = f"{REPOS_HOSTING_URL}/fake_yum0/"
 
 katello_ca_consumer = DOGFOOD_URL + "/pub/katello-ca-consumer-latest.noarch.rpm"


### PR DESCRIPTION
HOTFIX_URL is the only setting available in testfm.yaml, which uses @jameerpathan111 FTP to download hotfix-package

@shubhamsg199 Added and deployed hotfix-package package on fedorapeople-fixtures container https://github.com/SatelliteQE/fedorapeople-repos/pull/11 , so moving to use it instead of personal FTP.

**Tests Results:** 
```
(.testfm) ➜  testfm git:(master) ✗ pytest -q --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory tests/test_health.py -k test_positive_check_hotfix_installed
..                                                                                                                                                        [100%]
2 passed, 27 deselected in 441.96 seconds
```

Dependent MR for satelliteqe-jenkins: MR#524

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>