### PR TITLE
Fix hotfix related tests for RHEL8

### DIFF
--- a/testfm/constants.py
+++ b/testfm/constants.py
@@ -1,4 +1,5 @@
 from testfm import settings
+from testfm.helpers import rhel7
 
 RHN_USERNAME = settings.subscription.rhn_username
 RHN_PASSWORD = settings.subscription.rhn_password
@@ -99,3 +100,4 @@ foreman_maintain_yml = "/etc/foreman-maintain/foreman_maintain.yml"
 epel_repo = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
 satellite_answer_file = "/etc/foreman-installer/scenarios.d/satellite-answers.yaml"
 fm_hammer_yml = "/etc/foreman-maintain/foreman-maintain-hammer.yml"
+gems_path = f"""{f"{'/opt/theforeman/tfm/root' if rhel7() else ''}" + '/usr/share/gems/gems/'}"""

--- a/testfm/helpers.py
+++ b/testfm/helpers.py
@@ -14,13 +14,14 @@ def product():
 
 def run(command):
     """Use this helper to execute shell command on Satellite"""
-    return os.popen(f"ansible server -i testfm/inventory -u root -m command -a '{command}'").read()
+    return os.popen(f"ansible server -i testfm/inventory -u root -m shell -a '{command}'").read()
 
 
 def server():
     """Use this to find whether server on which tests are running is capsule or satellite."""
-    result = run("rpm -q satellite")
-    if "rc=0" in result:
-        return "satellite"
-    else:
-        return "capsule"
+    return "satellite" if "rc=0" in run("rpm -q satellite") else "capsule"
+
+
+def rhel7():
+    """Use this helper to find if satellite RHEL version is 7"""
+    return True if "rc=0" in run("rpm -qa rubygem-foreman_maintain | grep el7") else False


### PR DESCRIPTION
**Test Results:**
```
$ pytest -k test_positive_check_hotfix_installed -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory
========================================== test session starts =============================================
platform linux -- Python 3.8.6, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/sganar/foreman/fm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/sganar/foreman/testfm, inifile:
plugins: ansible-2.2.3
collected 86 items / 84 deselected                                                                                                                                                                                                                                                       

tests/test_health.py::test_positive_check_hotfix_installed PASSED                                                                                                                                                                                                                  [ 50%]
tests/test_health.py::test_positive_check_hotfix_installed_without_hotfix PASSED                                                                                                                                                                                                   [100%]

===================================== 2 passed, 84 deselected in 297.30 seconds ==========================================
```