### PR TITLE
[6.10.z]Fix hotfix tests

### DIFF
--- a/testfm/helpers.py
+++ b/testfm/helpers.py
@@ -19,8 +19,4 @@ def run(command):
 
 def server():
     """Use this to find whether server on which tests are running is capsule or satellite."""
-    result = run("rpm -q satellite")
-    if "rc=0" in result:
-        return "satellite"
-    else:
-        return "capsule"
+    return "satellite" if "rc=0" in run("rpm -q satellite") else "capsule"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,10 +64,8 @@ def setup_hotfix_check(request, ansible_module):
         pkgs_locked = ansible_module.command(Packages.is_locked()).values()[0]["rc"]
         if pkgs_locked == 0:
             ansible_module.command(Packages.unlock())
-        teardown = ansible_module.command("yum -y reinstall tfm-rubygem-fog-vsphere")
-        for result in teardown.values():
-            assert result["rc"] == 0
-
+        teardown = ansible_module.lineinfile(path=fpath, regexp="#modifying_file", state="absent")
+        assert teardown.values()[0]["changed"] is True
         teardown = ansible_module.file(path="/etc/yum.repos.d/hotfix_repo.repo", state="absent")
         assert teardown.values()[0]["changed"] == 1
         teardown = ansible_module.yum(name=["hotfix-package"], state="absent")


### PR DESCRIPTION
**`Test Results:`**

```
$ pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory tests/test_health.py -k test_positive_check_hotfix_installed
============================================ test session starts =============================================
platform linux -- Python 3.8.6, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/sganar/foreman/fm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/sganar/foreman/testfm, inifile:
plugins: ansible-2.2.3
collected 29 items / 27 deselected                                                                                                                                                                                                                                                       

tests/test_health.py::test_positive_check_hotfix_installed PASSED                                                                                                                                                                                                                  [ 50%]
tests/test_health.py::test_positive_check_hotfix_installed_without_hotfix PASSED                                                                                                                                                                                                   [100%]

==================================== 2 passed, 27 deselected in 234.19 seconds ==========================================
```
```
$ pytest -v --ansible-host-pattern server --ansible-user=root  --ansible-inventory testfm/inventory tests/test_health.py -k test_positive_check_non_rh_packages
============================================ test session starts =====================================================
platform linux -- Python 3.8.6, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/sganar/foreman/fm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/sganar/foreman/testfm, inifile:
plugins: ansible-2.2.3
collected 29 items / 28 deselected                                                                                                                                                                                                                                                       

tests/test_health.py::test_positive_check_non_rh_packages PASSED                                                                                                                                                                                                                   [100%]

================================== 1 passed, 28 deselected in 119.41 seconds ======================================================
```