### PR TITLE
Add check for duplicate permissions(BZ#1849110)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -631,3 +631,15 @@ def setup_rpmsave_file(request, ansible_module):
             assert result["changed"] is True
 
     request.addfinalizer(teardown_rpmsave_file)
+
+
+@pytest.fixture(scope="function")
+def setup_duplicate_permissions(request, ansible_module):
+    """This fixture is used to create duplicate permissions in the database"""
+    name = r"'\''view_ansible_variables'\''"
+    resource_type = r"'\''AnsibleVariable'\''"
+    setup = ansible_module.shell(
+        f'''sudo su - postgres -c "psql -d foreman -c 'INSERT INTO permissions(name, resource_type)
+        VALUES({name}, {resource_type});'"'''
+    )
+    assert setup.values()[0]["rc"] == 0

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -949,3 +949,39 @@ def test_positive_available_space_postgresql12(ansible_module):
 
     :CaseImportance: High
     """
+
+
+def test_positive_check_duplicate_permissions(ansible_module, setup_duplicate_permissions):
+    """Verify duplicate-permissions check
+
+    :id: 192a5943-43cc-4f89-9949-893c8011831a
+
+    :setup:
+        1. foreman-maintain should be installed.
+        2. Setup duplicate permissions in the database
+
+    :steps:
+        1. foreman-maintain health check --label duplicate-permissions
+
+    :expectedresults: Verify if the check passes and removes duplicate permissions.
+
+    :CaseImportance: High
+
+    :BZ: 1849110, 1884024
+
+    """
+    # Verify if check failed because of duplicate permissions
+    contacted = ansible_module.command(
+        Health.check(["--label", "duplicate-permissions", "--assumeyes"])
+    )
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "FAIL" in result["stdout"]
+        assert "Remove duplicate permissions from database" in result["stdout"]
+        assert result["rc"] == 0
+    # Verify the check passed
+    contacted = ansible_module.command(Health.check(["--label", "duplicate-permissions"]))
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "FAIL" not in result["stdout"]
+        assert result["rc"] == 0


### PR DESCRIPTION
**`Test Results:`**
**RHEL7:**
```
$ pytest -v --ansible-host-pattern server --ansible-user=root --ansible-inventory testfm/inventory -k test_positive_check_duplicate_permissions tests/test_health.py
========================================== test session starts =======================================================================
platform linux -- Python 3.8.6, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/sganar/foreman/fm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/sganar/foreman/testfm, inifile:
plugins: ansible-2.2.3
collected 30 items / 29 deselected                                                                                                                                                                                                                                                       

tests/test_health.py::test_positive_check_duplicate_permissions PASSED                                                                                                                                                                                                             [100%]
========================================= 1 passed, 29 deselected in 35.62 seconds ==============================================================
```
**RHEL8:**
```
$ pytest -v --ansible-host-pattern server --ansible-user=root --ansible-inventory testfm/inventory -k test_positive_check_duplicate_permissions tests/test_health.py
================================ test session starts ================================================================================
platform linux -- Python 3.8.6, pytest-3.6.1, py-1.10.0, pluggy-0.6.0 -- /home/sganar/foreman/fm/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /home/sganar/foreman/testfm, inifile:
plugins: ansible-2.2.3
collected 30 items / 29 deselected                                                                                                                                                                                                                                                       

tests/test_health.py::test_positive_check_duplicate_permissions PASSED                                                                                                                                                                                                             [100%]

======================================== 1 passed, 29 deselected in 28.98 seconds ===========================================================
```