### PR TITLE
Vault integration to access secrets via DynaConf

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Procedure to enable vault interation with robottelo:
+# 1. Copy .env.example to .env file to set this as root level directory for Dynaconf Vault integrtion
+# 2. Set VAULT_ENABLED_FOR_DYNACONF to true to enable vault integration
+# 3. Set right vaules for VAULT_URL_FOR_DYNACONF, VAULT_MOUNT_POINT_FOR_DYNACONF and VAULT_PATH_FOR_DYNACONF
+# 4. Run 'make vault-login' to login into vault and to generate and set th token automatically
+# 5. To use secret from vault for any settings in conf/*.yaml, use the format: '@format {this._secret_name_in_vault_}'
+# 6. bugzilla.yaml Example:
+#    BUGZILLA:
+#      URL: https://bugzilla.redhat.com
+#      API_KEY: '@format {this.vault_bz-api-key}'
+# 7. Execute command `vault kv get <full_path>` to list all the secrets from vault
+VAULT_ENABLED_FOR_DYNACONF=false
+VAULT_URL_FOR_DYNACONF=http://localhost:8200
+# Specify the secrets engine for kv, default is 1
+VAULT_KV_VERSION_FOR_DYNACONF=2
+# Specify certs to access secrets on https vault
+VAULT_VERIFY_FOR_DYNACONF=false
+# Authenticate with token https://www.vaultproject.io/docs/auth/token
+# VAULT_TOKEN_FOR_DYNACONF=myroot
+# Authenticate with AppRole https://www.vaultproject.io/docs/auth/approle
+# VAULT_ROLE_ID_FOR_DYNACONF=
+# VAULT_SECRET_ID_FOR_DYNACONF=
+# Authenticate with AWS IAM https://www.vaultproject.io/docs/auth/aws
+# The IAM Credentials can be retrieved from the standard providers: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
+# VAULT_AUTH_WITH_IAM_FOR_DYNACONF=False
+# VAULT_AUTH_ROLE_FOR_DYNACONF=vault-role
+# Authenticate with root token
+# VAULT_ROOT_TOKEN_FOR_DYNACONF=root-token
+# Path of secrets
+VAULT_MOUNT_POINT_FOR_DYNACONF=somemount
+VAULT_PATH_FOR_DYNACONF=somepath

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist/
 # Dynaconf local files
 /conf/*
 !/conf/testfm.sample.yaml
+
+# Dynaconfs .env file
+/.env

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,13 @@ uuid-check:  ## list duplicated or empty uuids
 uuid-fix:
 	@scripts/fix_uuids.sh
 
+vault-login:
+	@scripts/vault_login.py --login
+
+vault-status:
+	@scripts/vault_login.py --status
+
+vault-logout:
+	@scripts/vault_login.py --logout
+
 .PHONY: help test-docstrings uuid-check

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible==2.9.20
-dynaconf==3.1.4
+dynaconf[vault]==3.1.8
 fauxfactory==3.1.0
 pre-commit
 PyNaCl==1.4.0

--- a/scripts/vault_login.py
+++ b/scripts/vault_login.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# This Enables and Disables individuals OIDC token to access secrets from vault
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+
+class InvalidVaultURLForOIDC(Exception):
+    """Raised if the vault doesnt allows OIDC login"""
+
+
+HELP_TEXT = (
+    "Vault CLI in not installed in your system, "
+    "refer link https://learn.hashicorp.com/tutorials/vault/getting-started-install to "
+    "install vault CLI as per your system spec!"
+)
+
+# Color Codes
+YELLOW = "\033[1;33m"
+REDL = "\033[3;31m"
+REDD = "\033[1;31m"
+GREEN = "\033[1;32m"
+WHITEL = "\033[1;30m"
+
+
+def _load_env():
+    print("\nFetching vault data from .env file and Exporting vault URL .....\n")
+    ROOT_PATH = os.path.realpath(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.pardir)
+    )
+    with open(ROOT_PATH + "/.env") as envfile:
+        envdata = envfile.read()
+    return ROOT_PATH, envdata
+
+
+def _export_vault_url(envdata):
+    vaulturl = re.findall("VAULT_URL_FOR_DYNACONF=(.*)", envdata)[0]
+    if "localhost:8200" in vaulturl:
+        raise InvalidVaultURLForOIDC(
+            f"{REDL}{vaulturl} doesnt supports OIDC login,"
+            "please change url to corp vault in env file!"
+        )
+    os.environ["VAULT_ADDR"] = vaulturl
+
+
+def _vault_command(command: str):
+    vcommand = subprocess.run(command, capture_output=True, shell=True)
+    if vcommand.returncode != 0:
+        verror = str(vcommand.stderr)
+        if "vault: command not found" in verror:
+            print(f"{REDD}Error! {HELP_TEXT}")
+            sys.exit(1)
+        elif "Error revoking token" in verror:
+            print(f"{GREEN}Token is alredy revoked!")
+            sys.exit(0)
+        elif "Error looking up token" in verror:
+            print(f"{YELLOW}Warning! Vault not logged in, please run 'make vault-login'!")
+            sys.exit(2)
+        else:
+            print(f"{REDD}Error! {verror}")
+            sys.exit(1)
+    return vcommand
+
+
+def _vault_login(root_path, envdata):
+    print(
+        f"{WHITEL}Warning! The browser is about to open for vault OIDC login, "
+        "close the tab once the sign in is done!"
+    )
+    time.sleep(5)
+    if _vault_command(command="vault login -method=oidc").returncode == 0:
+        _vault_command(command="vault token renew -i 10h")
+        print(f"{GREEN}Success! Vault OIDC Logged-In and extended for 10 hours!")
+    # Fetching token
+    token = _vault_command("vault token lookup --format json").stdout
+    token = json.loads(str(token.decode("UTF-8")))["data"]["id"]
+    # Setting new token in env file
+    envdata = re.sub(".*VAULT_TOKEN_FOR_DYNACONF=.*", f"VAULT_TOKEN_FOR_DYNACONF={token}", envdata)
+    with open(root_path + "/.env", "w") as envfile:
+        envfile.write(envdata)
+    print(f"{GREEN}Success! New OIDC token is added to .env file to access secrets from vault!")
+
+
+def _vault_logout(root_path, envdata):
+    # Teardown - Setting dymmy token in env file
+    envdata = re.sub(".*VAULT_TOKEN_FOR_DYNACONF=.*", "# VAULT_TOKEN_FOR_DYNACONF=myroot", envdata)
+    with open(root_path + "/.env", "w") as envfile:
+        envfile.write(envdata)
+    _vault_command("vault token revoke -self")
+    print(f"{GREEN}Success! OIDC token removed from Env file successfully!")
+
+
+def _vault_status():
+    vstatus = _vault_command("vault token lookup")
+    if vstatus.returncode == 0:
+        print(str(vstatus.stdout.decode("UTF-8")))
+
+
+if __name__ == "__main__":
+    root_path, envdata = _load_env()
+    _export_vault_url(envdata)
+    if sys.argv[-1] == "--login":
+        _vault_login(root_path, envdata)
+    elif sys.argv[-1] == "--status":
+        _vault_status()
+    else:
+        _vault_logout(root_path, envdata)
+    # Unsetting VAULT URL
+    del os.environ["VAULT_ADDR"]

--- a/testfm/__init__.py
+++ b/testfm/__init__.py
@@ -10,6 +10,7 @@ settings = Dynaconf(
     includes=["conf/testfm.local.yaml"],
     envless_mode=True,
     lowercase_read=True,
+    load_dotenv=True,
     validators=[
         Validator(
             "subscription.rhn_username",


### PR DESCRIPTION
**Tests Results:**
```
(.testfm_vault) ➜  testfm git:(vault-integration) ✗ pytest -v --disable-warnings --ansible-host-pattern server --ansible-user root --ansible-inventory testfm/inventory tests/test_health.py -k test_positive_satellite_maintain_health_list
====================================================================== test session starts =======================================================================
platform darwin -- Python 3.8.10, pytest-3.6.1, py-1.11.0, pluggy-0.6.0 -- /Users/gtalreja/sat_workspace/testfm/.testfm_vault/bin/python
cachedir: .pytest_cache
ansible: 2.9.20
rootdir: /Users/gtalreja/sat_workspace/testfm, inifile:
plugins: ansible-2.2.4
collected 30 items / 28 deselected

tests/test_health.py::test_positive_satellite_maintain_health_list PASSED                                                                                  [ 50%]
tests/test_health.py::test_positive_satellite_maintain_health_list_tags PASSED                                                                             [100%]

============================================================ 2 passed, 28 deselected in 24.31 seconds ============================================================
```
**Dependant MR**: satelliteqe-jenkins MR#624

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>