### PR TITLE
Update validate-yum-config check test for BZ 2048986

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -428,7 +428,6 @@ def test_positive_check_validate_yum_config(ansible_module):
     """
     file = "/etc/yum.conf"
     yum_exclude = "exclude='cat* bear*'"
-    yum_clean_requirements = "clean_requirements_on_remove=1"
     failure_message = "Unset this configuration as it is risky while yum update or upgrade!"
     ansible_module.blockinfile(path=file, block=yum_exclude)
     contacted = ansible_module.command(Health.check({"label": "validate-yum-config"}))
@@ -438,19 +437,7 @@ def test_positive_check_validate_yum_config(ansible_module):
         assert failure_message in result["stdout"]
         assert result["rc"] == 1
 
-    ansible_module.blockinfile(path=file, block=f"{yum_exclude} \n{yum_clean_requirements}")
-
-    contacted = ansible_module.command(Health.check({"label": "validate-yum-config"}))
-    for result in contacted.values():
-        logger.info(result["stdout"])
-        assert yum_exclude in result["stdout"]
-        assert yum_clean_requirements in result["stdout"]
-        assert failure_message in result["stdout"]
-        assert result["rc"] == 1
-
-    ansible_module.blockinfile(
-        path=file, block=f"{yum_exclude} \n{yum_clean_requirements}", state="absent"
-    )
+    ansible_module.blockinfile(path=file, block=yum_exclude, state="absent")
     contacted = ansible_module.command(Health.check({"label": "validate-yum-config"}))
     for result in contacted.values():
         logger.info(result["stdout"])


### PR DESCRIPTION
**Descriptions:**
With recent change in 6.11 by [BZ 2048986](https://bugzilla.redhat.com/show_bug.cgi?id=2048986) removed the `clean_requirements_on_remove` parameter from the `validate-yum-config` check, this means the tests do not require this parameter to be asserted, thus it no longer requires an additional check.'

**Test Results:**
```
(.testfm) ➜  testfm git:(remove-clean-req) ✗ pytest -v --disable-warnings --ansible-host-pattern server --ansible-user root --ansible-inventory testfm/inventory tests/test_health.py -k test_positive_check_validate_yum_config
====================================================================== test session starts =======================================================================
platform darwin -- Python 3.8.10, pytest-3.6.1, py-1.11.0, pluggy-0.6.0 -- /Users/gtalreja/sat_workspace/testfm/.testfm/bin/python
cachedir: .pytest_cache
ansible: 2.12.1
rootdir: /Users/gtalreja/sat_workspace/testfm, inifile:
plugins: ansible-2.2.4
collected 30 items / 29 deselected

tests/test_health.py::test_positive_check_validate_yum_config PASSED                                                                                       [100%]

============================================================ 1 passed, 29 deselected in 29.48 seconds ============================================================
```

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>