### PR TITLE
Refactor product helper to read from dynaconf

### DIFF
--- a/testfm/helpers.py
+++ b/testfm/helpers.py
@@ -1,15 +1,12 @@
 # helpers required for TestFM
 import os
 
+from testfm import settings
+
 
 def product():
-    """This helper provides Satellite/Capsule version"""
-    server_version = os.popen(
-        "ansible -i testfm/inventory server --user root -m shell "
-        '-a "rpm -q satellite > /dev/null && rpm -q satellite --queryformat=%{VERSION}'
-        ' || rpm -q satellite-capsule --queryformat=%{VERSION}" -o'
-    ).read()
-    return server_version.splitlines()[0].split(" ")[-1][:3]
+    """Use this helper to fetch x.y version of Satellite/Capsule from x.y.z.v.w"""
+    return ".".join(settings.server.version.release.split(".")[:2])
 
 
 def run(command):


### PR DESCRIPTION
**Problem:**
A current approach to fetch versions using `product()` helper returns versions like `6.1` for 6.10.z and 6.11.z which caused a few tests to fail in automation

**Solution:**
```
In [1]: from testfm import settings

In [2]: from testfm.helpers import product

In [3]: settings.server.version.release
Out[3]: '6.11.0'

In [4]: product()
Out[4]: '6.11'

In [5]: settings.set("server.version.release", "6.10.6")

In [6]: settings.server.version.release
Out[6]: '6.10.6'

In [7]: product()
Out[7]: '6.10'
```
**Test Results:**
```
(.testfm) ➜  testfm git:(master) ✗ pytest -q --disable-warnings --ansible-host-pattern server --ansible-user root --ansible-inventory testfm/inventory tests/test_upgrade.py -k test_positive_repositories_validate
.                                                                                                                                                          [100%]
1 passed, 3 deselected in 37.19 seconds
```
Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>