### PR TITLE
Fix repo setup tests for missing maintain beta and not required ansible repo for el8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible==2.9.20
-dynaconf[vault]==3.1.8
+dynaconf[vault]==3.1.9
 fauxfactory==3.1.0
 pre-commit
 PyNaCl==1.4.0

--- a/testfm/constants.py
+++ b/testfm/constants.py
@@ -1,5 +1,6 @@
 from testfm import settings
 from testfm.helpers import rhel7
+from testfm.helpers import server
 
 RHN_USERNAME = settings.subscription.rhn_username
 RHN_PASSWORD = settings.subscription.rhn_password
@@ -38,7 +39,6 @@ common_repos = (
     else [
         "rhel-8-for-x86_64-baseos-rpms",
         "rhel-8-for-x86_64-appstream-rpms",
-        "ansible-2.9-for-rhel-8-x86_64-rpms",
     ]
 )
 
@@ -79,7 +79,6 @@ sat_beta_repo = (
     if rhel7()
     else [
         "satellite-6-beta-for-rhel-8-x86_64-rpms",
-        "satellite-maintenance-6-beta-for-rhel-8-x86_64-rpms",
     ]
 ) + common_repos
 
@@ -118,12 +117,17 @@ cap_beta_repo = (
         "rhel-7-server-satellite-maintenance-6-beta-rpms",
     ]
     if rhel7()
+    else []
+) + common_repos
+
+missing_beta_el8_repos = (
+    ["satellite-maintenance-6-beta-for-rhel-8-x86_64-rpms"]
+    if server() == "satellite"
     else [
         "satellite-capsule-6-beta-for-rhel-8-x86_64-rpms",
         "satellite-maintenance-6-beta-for-rhel-8-x86_64-rpms",
     ]
-) + common_repos
-
+)
 sat_repos = {
     "6.9": sat_69_repos,
     "6.10": sat_610_repos,

--- a/tests/test_advanced.py
+++ b/tests/test_advanced.py
@@ -6,6 +6,7 @@ from testfm.advanced_by_tag import AdvancedByTag
 from testfm.constants import cap_beta_repo
 from testfm.constants import cap_repos
 from testfm.constants import fm_hammer_yml
+from testfm.constants import missing_beta_el8_repos
 from testfm.constants import sat_beta_repo
 from testfm.constants import sat_repos
 from testfm.decorators import stubbed
@@ -394,28 +395,32 @@ def test_positive_satellite_repositories_setup(setup_subscribe_to_cdn_dogfood, a
             for repo in sat_repos[ver]:
                 assert repo in result["stdout"]
 
+    # 6.12 till not GA
+    contacted = ansible_module.command(Advanced.run_repositories_setup({"version": "6.12"}))
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "FAIL" in result["stdout"]
+        assert result["rc"] == 1
+        for repo in sat_repos["6.12"]:
+            assert repo in result["stdout"]
+
     # Verify that all required beta repositories gets enabled
+    # maintain beta repo is unavailable for EL8 https://bugzilla.redhat.com/show_bug.cgi?id=2106750
     export_command = "export FOREMAN_MAINTAIN_USE_BETA=1;"
     contacted = ansible_module.shell(
         export_command + Advanced.run_repositories_setup({"version": "6.11"})
     )
     for result in contacted.values():
         logger.info(result["stdout"])
-        assert "FAIL" not in result["stdout"]
-        assert result["rc"] == 0
+        assert "FAIL" in result["stdout"]
+        assert result["rc"] != 0
+        for repo in missing_beta_el8_repos:
+            assert f"Error: '{repo}' does not match a valid repository ID" in result["stdout"]
+
     contacted = ansible_module.command("yum repolist")
     for result in contacted.values():
         logger.info(result["stdout"])
         for repo in sat_beta_repo:
-            assert repo in result["stdout"]
-
-    # 6.12 till not GA
-    contacted = ansible_module.shell(Advanced.run_repositories_setup({"version": "6.12"}))
-    for result in contacted.values():
-        logger.info(result["stdout"])
-        assert "FAIL" in result["stdout"]
-        assert result["rc"] == 1
-        for repo in sat_repos["6.12"]:
             assert repo in result["stdout"]
 
 
@@ -450,26 +455,30 @@ def test_positive_capsule_repositories_setup(setup_subscribe_to_cdn_dogfood, ans
             logger.info(result["stdout"])
             for repo in cap_repos[ver]:
                 assert repo in result["stdout"]
+
+    # 6.12 till not GA
+    contacted = ansible_module.command(Advanced.run_repositories_setup({"version": "6.12"}))
+    for result in contacted.values():
+        logger.info(result["stdout"])
+        assert "FAIL" in result["stdout"]
+        assert result["rc"] == 1
+        for repo in cap_repos["6.12"]:
+            assert repo in result["stdout"]
+
     # Verify that all required beta repositories gets enabled
+    # maintain beta repo is unavailable for EL8 https://bugzilla.redhat.com/show_bug.cgi?id=2106750
     export_command = "export FOREMAN_MAINTAIN_USE_BETA=1;"
     contacted = ansible_module.shell(
         export_command + Advanced.run_repositories_setup({"version": "6.11"})
     )
     for result in contacted.values():
         logger.info(result["stdout"])
-        assert "FAIL" not in result["stdout"]
-        assert result["rc"] == 0
+        assert "FAIL" in result["stdout"]
+        assert result["rc"] != 0
+        for repo in missing_beta_el8_repos:
+            assert f"Error: '{repo}' does not match a valid repository ID" in result["stdout"]
     contacted = ansible_module.command("yum repolist")
     for result in contacted.values():
         logger.info(result["stdout"])
         for repo in cap_beta_repo:
-            assert repo in result["stdout"]
-
-    # 6.12 till not GA
-    contacted = ansible_module.shell(Advanced.run_repositories_setup({"version": "6.12"}))
-    for result in contacted.values():
-        logger.info(result["stdout"])
-        assert "FAIL" in result["stdout"]
-        assert result["rc"] == 1
-        for repo in cap_repos["6.12"]:
             assert repo in result["stdout"]


### PR DESCRIPTION
**Tests Results:**
```
(.testfm) ➜  testfm git:(remove-ansible-el8) ✗ pytest -q --disable-pytest-warnings --ansible-host-pattern server --ansible-user root --ansible-inventory testfm/inventory tests/test_advanced.py -k test_positive_satellite_repositories_setup
.                                                                                                                                                                     [100%]
1 passed, 13 deselected in 189.68 seconds
```
```
(.testfm) ➜  testfm git:(remove-ansible-el8) ✗ pytest -q -m capsule --disable-pytest-warnings --ansible-host-pattern server --ansible-user root --ansible-inventory testfm/inventory tests/test_advanced.py -k test_positive_capsule_repositories_setup
.                                                                                                                                                                     [100%]
1 passed, 13 deselected in 190.06 seconds
```